### PR TITLE
Add MagicCosmetics material loader support

### DIFF
--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -249,6 +249,12 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>com.github.FrancoBM12</groupId>
+      <artifactId>API-MagicCosmetics</artifactId>
+      <version>2.2.8</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>com.github.Zrips</groupId>
       <artifactId>Jobs</artifactId>
       <version>5.2.2.3</version>

--- a/pom.xml
+++ b/pom.xml
@@ -278,6 +278,7 @@
             <scope>system</scope>
             <systemPath>${basedir}/libs/zItems-1.0.0.jar</systemPath>
         </dependency>
+
         <dependency>
             <groupId>nexo</groupId>
             <artifactId>nexo</artifactId>
@@ -301,6 +302,13 @@
             <groupId>com.github.Traqueur-dev</groupId>
             <artifactId>CurrenciesAPI</artifactId>
             <version>7078a467bb</version>
+        </dependency>
+        <!-- MagicCosmetics -->
+        <dependency>
+            <groupId>com.github.FrancoBM12</groupId>
+            <artifactId>API-MagicCosmetics</artifactId>
+            <version>2.2.8</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/src/fr/maxlego08/menu/MenuPlugin.java
+++ b/src/fr/maxlego08/menu/MenuPlugin.java
@@ -23,16 +23,7 @@ import fr.maxlego08.menu.inventory.VInventoryManager;
 import fr.maxlego08.menu.inventory.inventories.InventoryDefault;
 import fr.maxlego08.menu.listener.AdapterListener;
 import fr.maxlego08.menu.listener.SwapKeyListener;
-import fr.maxlego08.menu.loader.materials.Base64Loader;
-import fr.maxlego08.menu.loader.materials.EcoLoader;
-import fr.maxlego08.menu.loader.materials.HeadDatabaseLoader;
-import fr.maxlego08.menu.loader.materials.ItemsAdderLoader;
-import fr.maxlego08.menu.loader.materials.NexoLoader;
-import fr.maxlego08.menu.loader.materials.NovaLoader;
-import fr.maxlego08.menu.loader.materials.OraxenLoader;
-import fr.maxlego08.menu.loader.materials.SlimeFunLoader;
-import fr.maxlego08.menu.loader.materials.ZHeadLoader;
-import fr.maxlego08.menu.loader.materials.ZItemsLoader;
+import fr.maxlego08.menu.loader.materials.*;
 import fr.maxlego08.menu.pattern.ZPatternManager;
 import fr.maxlego08.menu.placeholder.LocalPlaceholder;
 import fr.maxlego08.menu.players.ZDataManager;
@@ -191,6 +182,9 @@ public class MenuPlugin extends ZPlugin {
         }
         if (this.isEnable(Plugins.NEXO)) {
             this.inventoryManager.registerMaterialLoader(new NexoLoader());
+        }
+        if (this.isEnable(Plugins.MAGICCOSMETICS)) {
+            this.inventoryManager.registerMaterialLoader(new MagicCosmeticsLoader());
         }
         if (this.isEnable(Plugins.ITEMSADDER)) {
             this.inventoryManager.registerMaterialLoader(new ItemsAdderLoader(this));

--- a/src/fr/maxlego08/menu/loader/materials/MagicCosmeticsLoader.java
+++ b/src/fr/maxlego08/menu/loader/materials/MagicCosmeticsLoader.java
@@ -1,0 +1,21 @@
+package fr.maxlego08.menu.loader.materials;
+
+import fr.maxlego08.menu.api.loader.MaterialLoader;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import com.francobm.magicosmetics.api.MagicAPI;
+
+public class MagicCosmeticsLoader implements MaterialLoader {
+
+    @Override
+    public String getKey() {
+        return "magic_cosmetics";
+    }
+
+    @Override
+    public ItemStack load(Player player, YamlConfiguration configuration, String path, String materialString) {
+        return MagicAPI.getEquipped(player.getName(), materialString);
+
+    }
+}

--- a/src/fr/maxlego08/menu/zcore/utils/plugins/Plugins.java
+++ b/src/fr/maxlego08/menu/zcore/utils/plugins/Plugins.java
@@ -19,7 +19,8 @@ public enum Plugins {
 
 	JOBS("Jobs"),
 	LUCKPERMS("LuckPerms"),
-    NEXO("Nexo");
+    NEXO("Nexo"),
+	MAGICCOSMETICS("MagicCosmetics");
 
 	private final String name;
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -16,6 +16,7 @@ softdepend:
   - LuckPerms
   - zHead
   - zItems
+  - MagicCosmetics
 folia-supported: true
 loadbefore:
   - SuperiorSkyblock2


### PR DESCRIPTION
Add support for MagicCosmetics plugin with a new material loader.

Features:
- Add new material format: `magic_cosmetics:<HAT/BAG/WALKING_STICK/BALLOON/SPRAY>`
- Display current equipped cosmetics in real-time
- Compatible with all MagicCosmetics items

Usage example:
```yaml
items:
  magic_cometics_HAT:
    item:
      material: "magic_cosmetics:HAT"
      name: '&bHat'
    use-cache: false
    slots:
      - 1
  ```