### PR TITLE
Add CI/CD for zMenu API & Dev

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -30,10 +30,10 @@ jobs:
         uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
 
       - name: Build with Gradle
-        run: ./gradlew build -Darchive.classifier=DEV -Dgithub.commit${{ github.sha }}
+        run: ./gradlew build -Darchive.classifier=DEV -Dgithub.sha={{ github.sha }}
 
       - name: Publish on GCHR
-        run: ./gradlew API:publish -Darchive.classifier=DEV -Dgithub.commit=${{ github.sha }}
+        run: ./gradlew API:publish -Darchive.classifier=DEV -Dgithub.sha=${{ github.sha }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ACTOR: ${{ github.actor }}

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -49,11 +49,13 @@ jobs:
           echo "Finding zMenu JAR..."
           jar_path=$(find target/ -name 'zMenu-*.jar' | head -n 1)
           echo "Found zMenu JAR at: $jar_path"
-          echo "JAR_PATH=$jar_path >> $GITHUB_OUTPUT"
+          echo "JAR_PATH=$jar_path" >> $GITHUB_OUTPUT
 
       - name: Discord Webhook Action
         uses: tsickert/discord-webhook@v7.0.0
         with:
           webhook-url: ${{ secrets.WEBHOOK_URL }}
           content: "New development build of zMenu is available!"
-          filename: ${{ steps.find_jar.outputs.JAR_PATH }}
+          avatar-url: https://minecraft-inventory-builder.com/storage/images/9UgcfGZyrmbVrXw5lbj5kXq6fW8F4nhwj6Cx4nVG.png
+          username: zMenu
+          filename: ${{ steps.find_jar.outputs.jar_path }}

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -33,7 +33,7 @@ jobs:
         run: ./gradlew build -Darchive.classifier=DEV -Dgithub.commit${{ github.sha }}
 
       - name: Publish on GCHR
-        run: ./gradlew publish -Darchive.classifier=DEV -Dgithub.commit=${{ github.sha }}
+        run: ./gradlew API:publish -Darchive.classifier=DEV -Dgithub.commit=${{ github.sha }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ACTOR: ${{ github.actor }}

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -29,11 +29,16 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
 
+      - name: Make the short sha
+        id: short_sha
+        run: |
+          echo "GITHUB_SHA_SHORT=$(echo $GITHUB_SHA | cut -c1-7)" >> $GITHUB_OUTPUT
+
       - name: Build with Gradle
-        run: ./gradlew build -Darchive.classifier=DEV -Dgithub.sha=${{ github.sha }}
+        run: ./gradlew build -Darchive.classifier=DEV -Dgithub.sha=${{ steps.short_sha.outputs.GITHUB_SHA_SHORT }}
 
       - name: Publish on GCHR
-        run: ./gradlew API:publish -Darchive.classifier=DEV -Dgithub.sha=${{ github.sha }}
+        run: ./gradlew API:publish -Darchive.classifier=DEV -Dgithub.sha=${{ steps.short_sha.outputs.GITHUB_SHA_SHORT }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ACTOR: ${{ github.actor }}
@@ -44,7 +49,7 @@ jobs:
           echo "Finding zMenu JAR..."
           jar_path=$(find target/ -name 'zMenu-*.jar' | head -n 1)
           echo "Found zMenu JAR at: $jar_path"
-          echo "::set-output name=jar_path::$jar_path"
+          echo "jar_path=$jar_path >> $GITHUB_OUTPUT"
 
       - name: Discord Webhook Action
         uses: tsickert/discord-webhook@v7.0.0

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -50,4 +50,7 @@ jobs:
         uses: tsickert/discord-webhook@v7.0.0
         with:
           webhook-url: ${{ secrets.WEBHOOK_URL }}
+          content: "New development build of zMenu is available!"
+          avatar-url: https://minecraft-inventory-builder.com/storage/images/9UgcfGZyrmbVrXw5lbj5kXq6fW8F4nhwj6Cx4nVG.png
+          username: zMenu
           filename: ${{ steps.find_jar.outputs.jar_path }}

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -56,5 +56,4 @@ jobs:
         with:
           webhook-url: ${{ secrets.WEBHOOK_URL }}
           content: "New development build of zMenu is available!"
-          username: zMenu
           filename: ${{ steps.find_jar.outputs.JAR_PATH }}

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -37,3 +37,17 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ACTOR: ${{ github.actor }}
+
+      - name: Find zMenu JAR
+        id: find_jar
+        run: |
+          echo "Finding zMenu JAR..."
+          jar_path=$(find target/ -name 'zMenu-*.jar' | head -n 1)
+          echo "Found zMenu JAR at: $jar_path"
+          echo "::set-output name=jar_path::$jar_path"
+
+      - name: Discord Webhook Action
+        uses: tsickert/discord-webhook@v7.0.0
+        with:
+          webhook-url: ${{ secrets.WEBHOOK_URL }}
+          filename: ${{ steps.find_jar.outputs.jar_path }}

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -49,7 +49,7 @@ jobs:
           echo "Finding zMenu JAR..."
           jar_path=$(find target/ -name 'zMenu-*.jar' | head -n 1)
           echo "Found zMenu JAR at: $jar_path"
-          echo "jar_path=$jar_path >> $GITHUB_OUTPUT"
+          echo "JAR_PATH=$jar_path >> $GITHUB_OUTPUT"
 
       - name: Discord Webhook Action
         uses: tsickert/discord-webhook@v7.0.0
@@ -58,4 +58,4 @@ jobs:
           content: "New development build of zMenu is available!"
           avatar-url: https://minecraft-inventory-builder.com/storage/images/9UgcfGZyrmbVrXw5lbj5kXq6fW8F4nhwj6Cx4nVG.png
           username: zMenu
-          filename: ${{ steps.find_jar.outputs.jar_path }}
+          filename: ${{ steps.find_jar.outputs.JAR_PATH }}

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -31,3 +31,9 @@ jobs:
 
       - name: Build with Gradle
         run: ./gradlew build -Darchive.classifier=DEV -Dgithub.commit${{ github.sha }}
+
+      - name: Publish on GCHR
+        run: ./gradlew publish -Darchive.classifier=DEV -Dgithub.commit=${{ github.sha }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR: ${{ github.actor }}

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -56,6 +56,5 @@ jobs:
         with:
           webhook-url: ${{ secrets.WEBHOOK_URL }}
           content: "New development build of zMenu is available!"
-          avatar-url: https://minecraft-inventory-builder.com/storage/images/9UgcfGZyrmbVrXw5lbj5kXq6fW8F4nhwj6Cx4nVG.png
           username: zMenu
           filename: ${{ steps.find_jar.outputs.JAR_PATH }}

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -30,7 +30,7 @@ jobs:
         uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
 
       - name: Build with Gradle
-        run: ./gradlew build -Darchive.classifier=DEV -Dgithub.sha={{ github.sha }}
+        run: ./gradlew build -Darchive.classifier=DEV -Dgithub.sha=${{ github.sha }}
 
       - name: Publish on GCHR
         run: ./gradlew API:publish -Darchive.classifier=DEV -Dgithub.sha=${{ github.sha }}

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -30,4 +30,4 @@ jobs:
         uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
 
       - name: Build with Gradle
-        run: ./gradlew build
+        run: ./gradlew build -Darchive.classifier=DEV -Dgithub.commit${{ github.sha }}

--- a/API/build.gradle.kts
+++ b/API/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.gradle.internal.impldep.org.apache.commons.codec.digest.DigestUtils.sha
-
 plugins {
     `maven-publish`
 }
@@ -27,7 +25,7 @@ publishing {
     repositories {
         maven {
             name = "GitHubPackages"
-            url = uri("https://maven.pkg.github.com/Maxlego08/zMenu")
+            url = uri("https://maven.pkg.github.com/${System.getenv("GITHUB_ACTOR")}/zMenu")
             credentials {
                 username = project.findProperty("gpr.user") as String? ?: System.getenv("GITHUB_ACTOR")
                 password = project.findProperty("gpr.key") as String? ?: System.getenv("GITHUB_TOKEN")
@@ -38,7 +36,7 @@ publishing {
     publications {
         register<MavenPublication>("gpr") {
             artifactId = "${rootProject.name}-${project.name}"
-            from(components["java"])
+            artifact(tasks.shadowJar)
         }
     }
 }

--- a/API/build.gradle.kts
+++ b/API/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     `maven-publish`
 }
 
-extra.properties["sha"]?.let { sha ->
+rootProject.extra.properties["sha"]?.let { sha ->
     version = sha
 }
 

--- a/API/build.gradle.kts
+++ b/API/build.gradle.kts
@@ -37,8 +37,8 @@ publishing {
             // https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry#publishing-a-package
             pom {
                 groupId = project.group as String?
-                artifactId = rootProject.name.lowercase()
-                name = project.name
+                name = "${rootProject.name}-${project.name}"
+                artifactId = name.get().lowercase()
                 version = project.version as String?
             }
             artifact(tasks.shadowJar)

--- a/API/build.gradle.kts
+++ b/API/build.gradle.kts
@@ -1,46 +1,44 @@
-group "API"
+import org.gradle.internal.impldep.org.apache.commons.codec.digest.DigestUtils.sha
+
+plugins {
+    `maven-publish`
+}
+
+group = "${rootProject.group}.api"
+extra.properties["sha"]?.let { sha ->
+    version = sha
+}
 
 tasks {
     shadowJar {
-
-        exclude("com/cryptomorin/xseries/profiles/**")
-        exclude("com/cryptomorin/xseries/profiles/*/*")
-        exclude("com/cryptomorin/xseries/reflection/**")
-        exclude("com/cryptomorin/xseries/reflection/*/*")
-        exclude("com/cryptomorin/xseries/messages/*")
-        exclude("com/cryptomorin/xseries/particles/*")
-        exclude("com/cryptomorin/xseries/inventory/*")
-        exclude("com/cryptomorin/xseries/art/*")
-        exclude("com/cryptomorin/xseries/XAttribute*")
-        exclude("com/cryptomorin/xseries/XItemFlag*")
-        exclude("com/cryptomorin/xseries/XPatternType*")
-        exclude("com/cryptomorin/xseries/XBiome*")
-        exclude("com/cryptomorin/xseries/NMSExtras*")
-        exclude("com/cryptomorin/xseries/NoteBlockMusic*")
-        exclude("com/cryptomorin/xseries/SkullCacheListener*")
-        exclude("com/cryptomorin/xseries/XTag*")
-        exclude("com/cryptomorin/xseries/XPotion*")
-        exclude("com/cryptomorin/xseries/XMaterial*")
-        exclude("com/cryptomorin/xseries/XItemStack*")
-        exclude("com/cryptomorin/xseries/XBlock*")
-        exclude("com/cryptomorin/xseries/XEntity*")
-        exclude("com/cryptomorin/xseries/XEnchantment*")
-        exclude("com/cryptomorin/xseries/SkullUtils*")
-        exclude("com/cryptomorin/xseries/ReflectionUtils*")
-        exclude("com/cryptomorin/xseries/XWorldBorder*")
-
         relocate("com.tcoded.folialib", "fr.maxlego08.menu.hooks.folialib")
         relocate("fr.traqueur.currencies", "fr.maxlego08.menu.hooks.currencies")
-        relocate("de.tr7zw.changeme.nbtapi", "fr.maxlego08.menu.hooks.nbtapi")
         relocate("com.cryptomorin.xseries", "fr.maxlego08.menu.hooks.xseries")
-        relocate("fr.maxlego08.sarah", "fr.maxlego08.menu.hooks.sarah")
-        relocate("net.objecthunter.exp4j", "fr.maxlego08.menu.hooks.exp4j")
 
-        archiveFileName.set("${rootProject.name}-API-${rootProject.version}.jar")
         destinationDirectory.set(rootProject.extra["apiFolder"] as File)
     }
 
     build {
         dependsOn(shadowJar)
+    }
+}
+
+publishing {
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/Maxlego08/zMenu")
+            credentials {
+                username = project.findProperty("gpr.user") as String? ?: System.getenv("GITHUB_ACTOR")
+                password = project.findProperty("gpr.key") as String? ?: System.getenv("GITHUB_TOKEN")
+            }
+        }
+    }
+
+    publications {
+        register<MavenPublication>("gpr") {
+            artifactId = "${rootProject.name}-${project.name}"
+            from(components["java"])
+        }
     }
 }

--- a/API/build.gradle.kts
+++ b/API/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.util.Locale
+
 plugins {
     `maven-publish`
 }
@@ -35,7 +37,8 @@ publishing {
 
     publications {
         register<MavenPublication>("gpr") {
-            artifactId = "${rootProject.name}-${project.name}"
+            // https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry#publishing-a-package
+            artifactId = "${rootProject.name}-${project.name}".lowercase()
             artifact(tasks.shadowJar)
         }
     }

--- a/API/build.gradle.kts
+++ b/API/build.gradle.kts
@@ -1,10 +1,7 @@
-import java.util.Locale
-
 plugins {
     `maven-publish`
 }
 
-group = "${rootProject.group}.api"
 extra.properties["sha"]?.let { sha ->
     version = sha
 }
@@ -38,7 +35,12 @@ publishing {
     publications {
         register<MavenPublication>("gpr") {
             // https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry#publishing-a-package
-            artifactId = "${rootProject.name}-${project.name}".lowercase()
+            pom {
+                groupId = project.group as String?
+                artifactId = rootProject.name.lowercase()
+                name = project.name
+                version = project.version as String?
+            }
             artifact(tasks.shadowJar)
         }
     }

--- a/Hooks/CraftEngine/build.gradle.kts
+++ b/Hooks/CraftEngine/build.gradle.kts
@@ -5,7 +5,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly(project(":API"))
+    compileOnly(projects.api)
     compileOnly("net.momirealms:craft-engine-core:0.0.52")
     compileOnly("net.momirealms:craft-engine-bukkit:0.0.52")
 }

--- a/Hooks/Eco/build.gradle.kts
+++ b/Hooks/Eco/build.gradle.kts
@@ -6,6 +6,6 @@ repositories {
 
 
 dependencies {
-    compileOnly(project(":API"))
+    compileOnly(projects.api)
     compileOnly("com.willfp:eco:6.53.0")
 }

--- a/Hooks/HeadDataBase/build.gradle.kts
+++ b/Hooks/HeadDataBase/build.gradle.kts
@@ -1,6 +1,6 @@
 group = "Hooks:HeadDataBase"
 
 dependencies {
-    compileOnly(project(":API"))
+    compileOnly(projects.api)
     compileOnly("com.arcaniax:HeadDatabase-API:1.3.2")
 }

--- a/Hooks/Hmccosmetics/build.gradle.kts
+++ b/Hooks/Hmccosmetics/build.gradle.kts
@@ -6,6 +6,6 @@ repositories {
 
 
 dependencies {
-    compileOnly(project(":API"))
+    compileOnly(projects.api)
     compileOnly("com.hibiscusmc:HMCCosmetics:2.7.7")
 }

--- a/Hooks/ItemsAdder/build.gradle.kts
+++ b/Hooks/ItemsAdder/build.gradle.kts
@@ -5,6 +5,6 @@ repositories {
 }
 
 dependencies {
-    compileOnly(project(":API"))
+    compileOnly(projects.api)
     compileOnly("com.github.LoneDev6:api-itemsadder:3.6.1")
 }

--- a/Hooks/Jobs/build.gradle.kts
+++ b/Hooks/Jobs/build.gradle.kts
@@ -1,6 +1,6 @@
 group = "Hooks:Jobs"
 
 dependencies {
-    compileOnly(project(":API"))
+    compileOnly(projects.api)
     compileOnly(files("libs/Jobs5.2.2.3.jar"))
 }

--- a/Hooks/LuckPerms/build.gradle.kts
+++ b/Hooks/LuckPerms/build.gradle.kts
@@ -1,6 +1,6 @@
 group = "Hooks:LuckPerms"
 
 dependencies {
-    compileOnly(project(":API"))
+    compileOnly(projects.api)
     compileOnly("net.luckperms:api:5.4")
 }

--- a/Hooks/MagicCosmetics/build.gradle.kts
+++ b/Hooks/MagicCosmetics/build.gradle.kts
@@ -1,6 +1,6 @@
 group = "Hooks:MagicCosmetics"
 
 dependencies {
-    compileOnly(project(":API"))
+    compileOnly(projects.api)
     compileOnly("com.github.FrancoBM12:API-MagicCosmetics:2.2.8")
 }

--- a/Hooks/Nexo/build.gradle.kts
+++ b/Hooks/Nexo/build.gradle.kts
@@ -5,6 +5,6 @@ repositories {
 }
 
 dependencies {
-    compileOnly(project(":API"))
+    compileOnly(projects.api)
     compileOnly("com.nexomc:nexo:1.1.0")
 }

--- a/Hooks/Nova/build.gradle.kts
+++ b/Hooks/Nova/build.gradle.kts
@@ -5,6 +5,6 @@ repositories {
 }
 
 dependencies {
-    compileOnly(project(":API"))
+    compileOnly(projects.api)
     compileOnly("xyz.xenondevs.nova:nova-api:0.14.10")
 }

--- a/Hooks/Oraxen/build.gradle.kts
+++ b/Hooks/Oraxen/build.gradle.kts
@@ -5,6 +5,6 @@ repositories {
 }
 
 dependencies {
-    compileOnly(project(":API"))
+    compileOnly(projects.api)
     compileOnly("io.th0rgal:oraxen:1.190.0")
 }

--- a/Hooks/PacketEvents/build.gradle.kts
+++ b/Hooks/PacketEvents/build.gradle.kts
@@ -5,6 +5,6 @@ repositories {
 }
 
 dependencies {
-    compileOnly(project(":API"))
+    compileOnly(projects.api)
     compileOnly("com.github.retrooper:packetevents-spigot:2.7.0")
 }

--- a/Hooks/Paper/build.gradle.kts
+++ b/Hooks/Paper/build.gradle.kts
@@ -5,6 +5,6 @@ repositories {
 }
 
 dependencies {
-    compileOnly(project(":API"))
+    compileOnly(projects.api)
     compileOnly("net.kyori:adventure-text-minimessage:4.21.0")
 }

--- a/Hooks/Shopkeepers/build.gradle.kts
+++ b/Hooks/Shopkeepers/build.gradle.kts
@@ -5,6 +5,6 @@ repositories {
 }
 
 dependencies {
-    compileOnly(project(":API"))
+    compileOnly(projects.api)
     compileOnly(files("libs/ShopkeepersAPI-2.15.1.jar"))
 }

--- a/Hooks/SlimeFun/build.gradle.kts
+++ b/Hooks/SlimeFun/build.gradle.kts
@@ -1,6 +1,6 @@
 group = "Hooks:SlimeFun"
 
 dependencies {
-    compileOnly(project(":API"))
+    compileOnly(projects.api)
     compileOnly("com.github.Slimefun:Slimefun4:RC-34")
 }

--- a/Hooks/ZHead/build.gradle.kts
+++ b/Hooks/ZHead/build.gradle.kts
@@ -5,6 +5,6 @@ repositories {
 }
 
 dependencies {
-    compileOnly(project(":API"))
+    compileOnly(projects.api)
     compileOnly(files("libs/zHead-1.5.jar"))
 }

--- a/Hooks/ZItems/build.gradle.kts
+++ b/Hooks/ZItems/build.gradle.kts
@@ -5,6 +5,6 @@ repositories {
 }
 
 dependencies {
-    compileOnly(project(":API"))
+    compileOnly(projects.api)
     compileOnly(files("libs/zItems-1.0.0.jar"))
 }

--- a/Hooks/build.gradle.kts
+++ b/Hooks/build.gradle.kts
@@ -1,0 +1,7 @@
+group = "Hooks"
+
+dependencies {
+    rootProject.subprojects.filter { it.path.startsWith(":Hooks:") }.forEach { subproject ->
+        api(project(subproject.path))
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     `java-library`
-    `maven-publish`
     id("com.gradleup.shadow") version "9.0.0-beta11"
 }
 
@@ -9,10 +8,15 @@ version = "1.1.0.0"
 
 extra.set("targetFolder", file("target/"))
 extra.set("apiFolder", file("target-api/"))
+extra.set("classifier", System.getProperty("archive.classifier"))
+extra.set("sha", System.getProperty("github.sha"))
 
 allprojects {
     apply(plugin = "java-library")
     apply(plugin = "com.gradleup.shadow")
+
+    group = "fr.maxlego08.menu"
+    version = rootProject.version
 
     repositories {
         mavenLocal()
@@ -22,6 +26,38 @@ allprojects {
         maven(url = "https://hub.spigotmc.org/nexus/content/repositories/snapshots/")
         maven(url = "https://repo.extendedclip.com/content/repositories/placeholderapi/")
         maven(url = "https://libraries.minecraft.net/")
+    }
+
+    tasks.shadowJar {
+        exclude("com/cryptomorin/xseries/profiles/**")
+        exclude("com/cryptomorin/xseries/profiles/*/*")
+        exclude("com/cryptomorin/xseries/reflection/**")
+        exclude("com/cryptomorin/xseries/reflection/*/*")
+        exclude("com/cryptomorin/xseries/messages/*")
+        exclude("com/cryptomorin/xseries/particles/*")
+        exclude("com/cryptomorin/xseries/inventory/*")
+        exclude("com/cryptomorin/xseries/art/*")
+        exclude("com/cryptomorin/xseries/XAttribute*")
+        exclude("com/cryptomorin/xseries/XItemFlag*")
+        exclude("com/cryptomorin/xseries/XPatternType*")
+        exclude("com/cryptomorin/xseries/XBiome*")
+        exclude("com/cryptomorin/xseries/NMSExtras*")
+        exclude("com/cryptomorin/xseries/NoteBlockMusic*")
+        exclude("com/cryptomorin/xseries/SkullCacheListener*")
+        exclude("com/cryptomorin/xseries/XTag*")
+        exclude("com/cryptomorin/xseries/XPotion*")
+        exclude("com/cryptomorin/xseries/XMaterial*")
+        exclude("com/cryptomorin/xseries/XItemStack*")
+        exclude("com/cryptomorin/xseries/XBlock*")
+        exclude("com/cryptomorin/xseries/XEntity*")
+        exclude("com/cryptomorin/xseries/XEnchantment*")
+        exclude("com/cryptomorin/xseries/SkullUtils*")
+        exclude("com/cryptomorin/xseries/ReflectionUtils*")
+        exclude("com/cryptomorin/xseries/XWorldBorder*")
+
+        archiveBaseName.set("zMenu")
+        archiveAppendix.set(if (project.path == ":") "" else project.name)
+        archiveClassifier.set("")
     }
 
     tasks.compileJava {
@@ -50,44 +86,13 @@ repositories {
 }
 
 dependencies {
-
-    api(project(":API"))
+    api(projects.api)
+    api(projects.hooks)
     implementation("de.tr7zw:item-nbt-api:2.15.0")
-
-    rootProject.subprojects.filter { it.path.startsWith(":Hooks:") }.forEach { subproject ->
-        api(project(subproject.path))
-    }
 }
 
 tasks {
     shadowJar {
-
-        exclude("com/cryptomorin/xseries/profiles/**")
-        exclude("com/cryptomorin/xseries/profiles/*/*")
-        exclude("com/cryptomorin/xseries/reflection/**")
-        exclude("com/cryptomorin/xseries/reflection/*/*")
-        exclude("com/cryptomorin/xseries/messages/*")
-        exclude("com/cryptomorin/xseries/particles/*")
-        exclude("com/cryptomorin/xseries/inventory/*")
-        exclude("com/cryptomorin/xseries/art/*")
-        exclude("com/cryptomorin/xseries/XAttribute*")
-        exclude("com/cryptomorin/xseries/XItemFlag*")
-        exclude("com/cryptomorin/xseries/XPatternType*")
-        exclude("com/cryptomorin/xseries/XBiome*")
-        exclude("com/cryptomorin/xseries/NMSExtras*")
-        exclude("com/cryptomorin/xseries/NoteBlockMusic*")
-        exclude("com/cryptomorin/xseries/SkullCacheListener*")
-        exclude("com/cryptomorin/xseries/XTag*")
-        exclude("com/cryptomorin/xseries/XPotion*")
-        exclude("com/cryptomorin/xseries/XMaterial*")
-        exclude("com/cryptomorin/xseries/XItemStack*")
-        exclude("com/cryptomorin/xseries/XBlock*")
-        exclude("com/cryptomorin/xseries/XEntity*")
-        exclude("com/cryptomorin/xseries/XEnchantment*")
-        exclude("com/cryptomorin/xseries/SkullUtils*")
-        exclude("com/cryptomorin/xseries/ReflectionUtils*")
-        exclude("com/cryptomorin/xseries/XWorldBorder*")
-
         relocate("com.tcoded.folialib", "fr.maxlego08.menu.hooks.folialib")
         relocate("fr.traqueur.currencies", "fr.maxlego08.menu.hooks.currencies")
         relocate("de.tr7zw.changeme.nbtapi", "fr.maxlego08.menu.hooks.nbtapi")
@@ -95,9 +100,10 @@ tasks {
         relocate("fr.maxlego08.sarah", "fr.maxlego08.menu.hooks.sarah")
         relocate("net.objecthunter.exp4j", "fr.maxlego08.menu.hooks.exp4j")
 
-        archiveClassifier = ""
-
-        archiveFileName.set("${rootProject.name}-${rootProject.version}.jar")
+        archiveClassifier = if (System.getProperty("github.commit") != null)
+            "${System.getProperty("archive.classifier")}-${System.getProperty("github.commit")}"
+        else
+            System.getProperty("archive.classifier")
         destinationDirectory.set(rootProject.extra["targetFolder"] as File)
     }
 
@@ -113,17 +119,6 @@ tasks {
         from("resources")
         filesMatching("plugin.yml") {
             expand("version" to project.version)
-        }
-    }
-}
-
-publishing {
-    publications {
-        create<MavenPublication>("maven") {
-            groupId = project.group.toString()
-            artifactId = project.name
-            version = project.version.toString()
-            from(project.components["java"])
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.internal.impldep.org.apache.commons.codec.digest.DigestUtils.sha
+
 plugins {
     `java-library`
     id("com.gradleup.shadow") version "9.0.0-beta11"
@@ -100,10 +102,11 @@ tasks {
         relocate("fr.maxlego08.sarah", "fr.maxlego08.menu.hooks.sarah")
         relocate("net.objecthunter.exp4j", "fr.maxlego08.menu.hooks.exp4j")
 
-        archiveClassifier = if (System.getProperty("github.commit") != null)
-            "${System.getProperty("archive.classifier")}-${System.getProperty("github.commit")}"
-        else
-            System.getProperty("archive.classifier")
+        rootProject.extra.properties["sha"]?.let { sha ->
+            archiveClassifier.set("${rootProject.extra.properties["classifier"]}-${sha}")
+        } ?: run {
+            archiveClassifier.set(rootProject.extra.properties["classifier"] as String?)
+        }
         destinationDirectory.set(rootProject.extra["targetFolder"] as File)
     }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,20 +1,13 @@
 rootProject.name = "zMenu"
 
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
+
 include("API")
-include("Hooks:ItemsAdder")
-include("Hooks:HeadDataBase")
-include("Hooks:CraftEngine")
-include("Hooks:Eco")
-include("Hooks:Hmccosmetics")
-include("Hooks:MagicCosmetics")
-include("Hooks:Nexo")
-include("Hooks:Nova")
-include("Hooks:Oraxen")
-include("Hooks:SlimeFun")
-include("Hooks:ZHead")
-include("Hooks:ZItems")
-include("Hooks:PacketEvents")
-include("Hooks:LuckPerms")
-include("Hooks:Shopkeepers")
-include("Hooks:Jobs")
-include("Hooks:Paper")
+
+file("Hooks").listFiles()?.forEach { file ->
+    if (file.isDirectory and !file.name.equals("build")) {
+        println("Include Hooks:${file.name}")
+        include(":Hooks:${file.name}")
+    }
+}
+


### PR DESCRIPTION
This pull request introduces several enhancements and refactors to the build configuration and CI/CD pipeline for the project. The most significant changes include adding Maven publishing support, improving the GitHub Actions workflow for publishing and notifications, and refactoring dependencies across multiple subprojects for consistency.

### CI/CD Enhancements:
* Updated `.github/workflows/maven-publish.yml` to include steps for generating a short Git SHA, building with a development classifier, publishing artifacts to GitHub Container Registry (GCHR), and notifying via Discord webhook upon successful builds.

### Build Configuration Improvements:
* Added Maven publishing configuration to `API/build.gradle.kts`, enabling publication of artifacts to GitHub Packages. This includes setting up repositories and publications for the Maven registry.

### Dependency Refactoring:
* Refactored dependencies in multiple `build.gradle.kts` files (e.g., `Hooks/CraftEngine/build.gradle.kts`, `Hooks/Eco/build.gradle.kts`) to replace `project(":API")` with `projects.api` for improved readability and consistency. [[1]](diffhunk://#diff-f955641c3babef5fbac4f83c68d55264d48234cef9de73a572f357e40d77f10cL8-R8) [[2]](diffhunk://#diff-a80523b1a053a344c0ddc91e251a8af5f6dd4a3c4724992dc634145223c117bfL9-R9) [[3]](diffhunk://#diff-87a7e232b837dfdd6f96ee61f66b4fb301c149382eb2fa9f9e106633d8a06bfeL4-R4) and others)

### New Grouping for Hooks:
* Added a new `group` and `dependencies` section in `Hooks/build.gradle.kts` to centralize and manage dependencies for all Hook subprojects.