### PR TITLE
Minor Update

### DIFF
--- a/API/src/main/java/fr/maxlego08/menu/api/Inventory.java
+++ b/API/src/main/java/fr/maxlego08/menu/api/Inventory.java
@@ -58,7 +58,7 @@ public interface Inventory {
      * Indicates whether the inventory prevents the player from picking up items from the ground.
      * @return true if item pickup is blocked while this inventory is open, false otherwise.
      */
-    boolean isCancelItemPickup();
+    boolean shouldCancelItemPickup();
 
     /**
      * Returns the name of the file associated with the inventory.

--- a/API/src/main/java/fr/maxlego08/menu/api/MenuItemStack.java
+++ b/API/src/main/java/fr/maxlego08/menu/api/MenuItemStack.java
@@ -196,4 +196,7 @@ public interface MenuItemStack {
 
     int parseAmount(OfflinePlayer offlinePlayer, Placeholders placeholders);
 
+    String getItemModel();
+
+    void setItemModel(String itemModel);
 }

--- a/src/main/java/fr/maxlego08/menu/ZInventory.java
+++ b/src/main/java/fr/maxlego08/menu/ZInventory.java
@@ -48,7 +48,7 @@ public class ZInventory extends ZUtils implements Inventory {
     private int updateInterval;
     private File file;
     private boolean clearInventory;
-    private boolean cancelItemPickup;
+    private boolean ItemPickupDisabled;
     private Requirement openRequirement;
     private OpenWithItem openWithItem;
     private InventoryType type = InventoryType.CHEST;
@@ -104,10 +104,10 @@ public class ZInventory extends ZUtils implements Inventory {
         this.type = type;
     }
     @Override
-    public boolean isCancelItemPickup() {return cancelItemPickup;}
+    public boolean shouldCancelItemPickup() {return ItemPickupDisabled;}
 
-    public void setCancelItemPickup(boolean cancelItemPickup) {
-        this.cancelItemPickup = cancelItemPickup;
+    public void setCancelItemPickup(boolean ItemPickupDisabled) {
+        this.ItemPickupDisabled = ItemPickupDisabled;
     }
 
     @Override
@@ -198,9 +198,10 @@ public class ZInventory extends ZUtils implements Inventory {
     private void clearPlayerInventoryButtons(Player player, InventoryEngine inventoryDefault) {
         for (Button button : getButtons()) {
             if (button.isPlayerInventory()) {
-                int slot = button.getRealSlot(36, inventoryDefault.getPage());
-                if (slot >= 0 && slot <= 36) {
-                    player.getInventory().setItem(slot, new ItemStack(Material.AIR));
+                for (int slot : button.getSlots()){
+                    if (slot >= 0 && slot <= 36) {
+                        player.getInventory().setItem(slot, new ItemStack(Material.AIR));
+                    }
                 }
             }
         }

--- a/src/main/java/fr/maxlego08/menu/ZMenuItemStack.java
+++ b/src/main/java/fr/maxlego08/menu/ZMenuItemStack.java
@@ -72,6 +72,7 @@ public class ZMenuItemStack extends ZUtils implements MenuItemStack {
     private Map<String, List<String>> translatedLore = new HashMap<>();
     private boolean isGlowing;
     private String modelID;
+    private String itemModel;
     private Map<Enchantment, Integer> enchantments = new HashMap<>();
     private List<IAttribute> attributes = new ArrayList<>();
     private Banner banner;
@@ -400,7 +401,12 @@ public class ZMenuItemStack extends ZUtils implements MenuItemStack {
                 itemMeta.setTooltipStyle(new NamespacedKey(tooltipstyleSplit[0], tooltipstyleSplit[1]));
             }
         }
-
+        if (this.itemModel != null) {
+            String[] itemModelSplit = this.itemModel.split(":", 2);
+            if (itemModelSplit.length == 2) {
+                itemMeta.setItemModel(new NamespacedKey(itemModelSplit[0], itemModelSplit[1]));
+            }
+        }
     }
 
     private void buildTrimAPI(ItemStack itemStack, ItemMeta itemMeta, Player player, Placeholders placeholders) {
@@ -670,6 +676,15 @@ public class ZMenuItemStack extends ZUtils implements MenuItemStack {
         this.tooltipstyle = toolTipStyle;
     }
 
+    @Override
+    public String getItemModel() {
+        return itemModel;
+    }
+
+    @Override
+    public void setItemModel(String itemModel) {
+        this.itemModel = itemModel;
+    }
 
     @Override
     public String getFilePath() {

--- a/src/main/java/fr/maxlego08/menu/command/VCommandManager.java
+++ b/src/main/java/fr/maxlego08/menu/command/VCommandManager.java
@@ -172,10 +172,11 @@ public class VCommandManager extends ZUtils implements CommandExecutor, TabCompl
             List<String> tabCompleter = new ArrayList<>();
             for (VCommand vCommand : this.commands) {
                 if ((vCommand.getParent() != null && vCommand.getParent() == command)) {
-                    String cmd = vCommand.getSubCommands().get(0);
-                    if (vCommand.getPermission() == null || sender.hasPermission(vCommand.getPermission())) {
-                        if (startWith.length() == 0 || cmd.startsWith(startWith)) {
-                            tabCompleter.add(cmd);
+                    for (String subCommand : vCommand.getSubCommands()) {
+                        if (vCommand.getPermission() == null || sender.hasPermission(vCommand.getPermission())) {
+                            if (startWith.isEmpty() || subCommand.startsWith(startWith)) {
+                                tabCompleter.add(subCommand);
+                            }
                         }
                     }
                 }

--- a/src/main/java/fr/maxlego08/menu/inventory/VInventoryManager.java
+++ b/src/main/java/fr/maxlego08/menu/inventory/VInventoryManager.java
@@ -188,7 +188,7 @@ public class VInventoryManager extends ListenerAdapter {
         if (holder instanceof VInventory vInventory) {
             if (vInventory instanceof InventoryDefault inventoryDefault){
                 fr.maxlego08.menu.api.Inventory menu = inventoryDefault.getMenuInventory();
-                if (menu != null && menu.isCancelItemPickup()) {
+                if (menu != null && menu.shouldCancelItemPickup()) {
                     event.setCancelled(true);
                 }
             }

--- a/src/main/java/fr/maxlego08/menu/loader/MenuItemStackLoader.java
+++ b/src/main/java/fr/maxlego08/menu/loader/MenuItemStackLoader.java
@@ -443,6 +443,10 @@ public class MenuItemStackLoader extends ZUtils implements Loader<MenuItemStack>
         if (tooltypestyleString != null) {
             menuItemStack.setToolTipStyle(tooltypestyleString);
         }
+        String itemModelString = configuration.getString(path + "item-model", null);
+        if (itemModelString != null) {
+            menuItemStack.setItemModel(itemModelString);
+        }
 
     }
 


### PR DESCRIPTION
- Rename item pickup methods for clarity
- item-model support "x:x" #Example : "minecraft:my_item"
- Update ClearButton method
- Update TabCompleter for subCommand