### PR TITLE
Add reusable github actions

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -3,6 +3,8 @@ name: Build Action
 on:
   push:
     branches: [ release/rework-gradle ]
+  pull_request:
+    types: [ opened, reopened ]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -18,4 +18,5 @@ jobs:
       publish: true
       project-to-publish: "API:publish"
       discord-avatar-url: "https://minecraft-inventory-builder.com/storage/images/9UgcfGZyrmbVrXw5lbj5kXq6fW8F4nhwj6Cx4nVG.png"
-    secrets: inherit
+    secrets:
+      WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -15,6 +15,8 @@ jobs:
   build:
     name: Build and Publish zMenu
     uses: GroupeZ-dev/actions/.github/workflows/build.yml@main
+    permissions:
+      pull-requests: write
     with:
       project-name: "zMenu"
       publish: true

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -1,4 +1,4 @@
-name: Gradle Package
+name: Build Action
 
 on:
   push:
@@ -11,51 +11,11 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up JDK 21
-        uses: actions/setup-java@v4
-        with:
-          java-version: '21'
-          distribution: 'temurin'
-          server-id: github
-          settings-path: ${{ github.workspace }}
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
-
-      - name: Make the short sha
-        id: short_sha
-        run: |
-          echo "GITHUB_SHA_SHORT=$(echo $GITHUB_SHA | cut -c1-7)" >> $GITHUB_OUTPUT
-
-      - name: Build with Gradle
-        run: ./gradlew build -Darchive.classifier=DEV -Dgithub.sha=${{ steps.short_sha.outputs.GITHUB_SHA_SHORT }}
-
-      - name: Publish on GCHR
-        run: ./gradlew API:publish -Darchive.classifier=DEV -Dgithub.sha=${{ steps.short_sha.outputs.GITHUB_SHA_SHORT }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_ACTOR: ${{ github.actor }}
-
-      - name: Find zMenu JAR
-        id: find_jar
-        run: |
-          echo "Finding zMenu JAR..."
-          jar_path=$(find target/ -name 'zMenu-*.jar' | head -n 1)
-          echo "Found zMenu JAR at: $jar_path"
-          echo "JAR_PATH=$jar_path" >> $GITHUB_OUTPUT
-
-      - name: Discord Webhook Action
-        uses: tsickert/discord-webhook@v7.0.0
-        with:
-          webhook-url: ${{ secrets.WEBHOOK_URL }}
-          content: "New development build of zMenu is available!"
-          avatar-url: https://minecraft-inventory-builder.com/storage/images/9UgcfGZyrmbVrXw5lbj5kXq6fW8F4nhwj6Cx4nVG.png
-          username: zMenu
-          filename: ${{ steps.find_jar.outputs.jar_path }}
+    name: Build and Publish zMenu
+    uses: GroupeZ-dev/actions/.github/workflows/build.yml@main
+    with:
+      project-name: "zMenu"
+      publish: true
+      project-to-publish: "API:publish"
+      discord-avatar-url: "https://minecraft-inventory-builder.com/storage/images/9UgcfGZyrmbVrXw5lbj5kXq6fW8F4nhwj6Cx4nVG.png"
+    secrets: inherit


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for building and publishing the `zMenu` project. The changes simplify the workflow by replacing custom steps with a reusable workflow and adding support for pull request events.

### Workflow improvements:

* **Workflow name and event triggers**: Renamed the workflow from "Gradle Package" to "Build Action" and added support for `pull_request` events (types `opened` and `reopened`) in addition to `push` and `workflow_dispatch` events. (`.github/workflows/maven-publish.yml`, [.github/workflows/maven-publish.ymlL1-R7](diffhunk://#diff-a31c6ada558b9f058a611b68d3f9cb0b9a901072c89d38fddc03cf929ef01e8aL1-R7))
* **Reusable workflow**: Replaced the custom build and publish steps with a reusable workflow (`GroupeZ-dev/actions/.github/workflows/build.yml@main`) to streamline the process. This includes parameters for project name, publishing, and Discord webhook details. (`.github/workflows/maven-publish.yml`, [.github/workflows/maven-publish.ymlL14-R24](diffhunk://#diff-a31c6ada558b9f058a611b68d3f9cb0b9a901072c89d38fddc03cf929ef01e8aL14-R24))