### PR TITLE
feat(loader): Add support for tipped arrow

### DIFF
--- a/API/src/main/java/fr/maxlego08/menu/api/itemstack/Potion.java
+++ b/API/src/main/java/fr/maxlego08/menu/api/itemstack/Potion.java
@@ -25,6 +25,7 @@ public class Potion {
     private static PotionBrewer brewer;
     private boolean extended = false;
     private boolean splash = false;
+    private boolean arrow = false;
     private int level = 1;
     private PotionType type;
     private Color color;
@@ -72,14 +73,16 @@ public class Potion {
      * @param type     The type of potion.
      * @param level    The potion's level.
      * @param splash   Whether it is a splash potion.
-     * @param extended Whether it has an extended duration. In favour of using
-     *                 {@link #Potion(PotionType)} with {@link #extend()} and
+     * @param extended Whether it has an extended duration.
+     *                 In favor of using {@link #Potion(PotionType)} with {@link #extend()} and
      *                 possibly {@link #splash()}.
+     * @param isArrow  Whether it is an arrow potion.
      */
 
-    public Potion(PotionType type, int level, boolean splash, boolean extended) {
+    public Potion(PotionType type, int level, boolean splash, boolean extended, boolean isArrow) {
         this(type, level, splash);
         this.extended = extended;
+        this.arrow = isArrow;
     }
 
     /**
@@ -90,53 +93,23 @@ public class Potion {
      */
 
     public static Potion fromDamage(int damage) {
-        PotionType type;
-        switch (damage & POTION_BIT) {
-            case 0:
-                type = PotionType.WATER;
-                break;
-            case 1:
-                type = PotionType.valueOf("REGEN");
-                break;
-            case 2:
-                type = PotionType.valueOf("SPEED");
-                break;
-            case 3:
-                type = PotionType.FIRE_RESISTANCE;
-                break;
-            case 4:
-                type = PotionType.POISON;
-                break;
-            case 5:
-                type = PotionType.valueOf("INSTANT_HEAL");
-                break;
-            case 6:
-                type = PotionType.NIGHT_VISION;
-                break;
-            case 8:
-                type = PotionType.WEAKNESS;
-                break;
-            case 9:
-                type = PotionType.STRENGTH;
-                break;
-            case 10:
-                type = PotionType.SLOWNESS;
-                break;
-            case 11:
-                type = PotionType.valueOf("JUMP");
-                break;
-            case 12:
-                type = PotionType.valueOf("INSTANT_DAMAGE");
-                break;
-            case 13:
-                type = PotionType.WATER_BREATHING;
-                break;
-            case 14:
-                type = PotionType.INVISIBILITY;
-                break;
-            default:
-                type = PotionType.WATER;
-        }
+        PotionType type = switch (damage & POTION_BIT) {
+//            case 0 -> PotionType.WATER;
+            case 1 -> PotionType.valueOf("REGEN");
+            case 2 -> PotionType.valueOf("SPEED");
+            case 3 -> PotionType.FIRE_RESISTANCE;
+            case 4 -> PotionType.POISON;
+            case 5 -> PotionType.valueOf("INSTANT_HEAL");
+            case 6 -> PotionType.NIGHT_VISION;
+            case 8 -> PotionType.WEAKNESS;
+            case 9 -> PotionType.STRENGTH;
+            case 10 -> PotionType.SLOWNESS;
+            case 11 -> PotionType.valueOf("JUMP");
+            case 12 -> PotionType.valueOf("INSTANT_DAMAGE");
+            case 13 -> PotionType.WATER_BREATHING;
+            case 14 -> PotionType.INVISIBILITY;
+            default -> PotionType.WATER;
+        };
         Potion potion;
         if (type == PotionType.WATER) {
             potion = new Potion(PotionType.WATER);
@@ -195,6 +168,17 @@ public class Potion {
 
     public Potion extend() {
         setHasExtendedDuration(true);
+        return this;
+    }
+
+    /**
+     * Chain this to the constructor to make the potion an arrow potion.
+     * Arrow potions are used in tipped arrows.
+     *
+     * @return The potion.
+     */
+    public Potion arrow() {
+        setArrow(true);
         return this;
     }
 
@@ -350,6 +334,25 @@ public class Potion {
     }
 
     /**
+     * Returns whether this potion is an arrow potion.
+     *
+     * @return Whether this is an arrow potion
+     */
+    public boolean isArrow() {
+        return arrow;
+    }
+
+    /**
+     * Sets whether this potion is an arrow potion.
+     * Arrow potions are tipped arrows.
+     *
+     * @param isArrow Whether this is an arrow potion
+     */
+    public void setArrow(boolean isArrow) {
+        this.arrow = isArrow;
+    }
+
+    /**
      * Converts this potion to a valid potion damage short, usable for potion
      * item stacks.
      *
@@ -370,14 +373,15 @@ public class Potion {
 
     public ItemStack toItemStack(int amount) {
         Material material;
-        if (isSplash()) {
+        if (isArrow())
+            material = Material.TIPPED_ARROW;
+        else if (isSplash())
             material = Material.SPLASH_POTION;
-        } else {
+        else
             material = Material.POTION;
-        }
         ItemStack itemStack = new ItemStack(material, amount);
         PotionMeta meta = (PotionMeta) itemStack.getItemMeta();
-        meta.setBasePotionData(new PotionData(type, level == 2, extended));
+        meta.setBasePotionData(new PotionData(type, extended, level == 2));
         if (color != null) meta.setColor(color);
         itemStack.setItemMeta(meta);
         return itemStack;

--- a/src/main/java/fr/maxlego08/menu/ZMenuItemStack.java
+++ b/src/main/java/fr/maxlego08/menu/ZMenuItemStack.java
@@ -764,8 +764,9 @@ public class ZMenuItemStack extends ZUtils implements MenuItemStack {
             int level = configuration.getInt("level", 1);
             boolean splash = configuration.getBoolean("splash", false);
             boolean extended = configuration.getBoolean("extended", false);
+            boolean arrow = configuration.getBoolean("arrow", false);
 
-            Potion potion = new Potion(type, level, splash, extended);
+            Potion potion = new Potion(type, level, splash, extended, arrow);
             potion.setColor(potionColor);
             setPotion(potion);
         }

--- a/src/main/java/fr/maxlego08/menu/loader/MenuItemStackLoader.java
+++ b/src/main/java/fr/maxlego08/menu/loader/MenuItemStackLoader.java
@@ -251,8 +251,9 @@ public class MenuItemStackLoader extends ZUtils implements Loader<MenuItemStack>
             int level = configuration.getInt(path + "level", 1);
             boolean splash = configuration.getBoolean(path + "splash", false);
             boolean extended = configuration.getBoolean(path + "extended", false);
+            boolean arrow = configuration.getBoolean(path + "arrow", false);
 
-            Potion potion = new Potion(type, level, splash, extended);
+            Potion potion = new Potion(type, level, splash, extended, arrow);
             potion.setColor(potionColor);
             menuItemStack.setPotion(potion);
         }

--- a/src/main/java/fr/maxlego08/menu/zcore/utils/loader/ItemStackLoader.java
+++ b/src/main/java/fr/maxlego08/menu/zcore/utils/loader/ItemStackLoader.java
@@ -65,8 +65,9 @@ public class ItemStackLoader extends ZUtils implements Loader<ItemStack> {
             int level = configuration.getInt(path + "level", 1);
             boolean splash = configuration.getBoolean(path + "splash", false);
             boolean extended = configuration.getBoolean(path + "extended", false);
+            boolean arrow = configuration.getBoolean(path + "arrow", false);
 
-            item = new Potion(type, level, splash, extended).toItemStack(amount);
+            item = new Potion(type, level, splash, extended, arrow).toItemStack(amount);
 
         }
 


### PR DESCRIPTION
This pull request introduces support for "arrow potions" in the `Potion` class and updates related classes and methods to accommodate this new feature. Key changes include adding the `arrow` property, modifying constructors, and updating serialization and deserialization logic to handle arrow potions.

### Enhancements to `Potion` class:

* Added a new `arrow` property to the `Potion` class, along with corresponding getter (`isArrow`) and setter (`setArrow`) methods. This property indicates whether the potion is an arrow potion. [[1]](diffhunk://#diff-12f3239dd2bb11d71553f400f15c3aff7a482aae5b6b7f1a0689d5494c3d1598R28) [[2]](diffhunk://#diff-12f3239dd2bb11d71553f400f15c3aff7a482aae5b6b7f1a0689d5494c3d1598R336-R354)
* Updated the `Potion` constructor to include the `arrow` parameter and added a chainable `arrow()` method for marking potions as arrow potions. [[1]](diffhunk://#diff-12f3239dd2bb11d71553f400f15c3aff7a482aae5b6b7f1a0689d5494c3d1598L75-R85) [[2]](diffhunk://#diff-12f3239dd2bb11d71553f400f15c3aff7a482aae5b6b7f1a0689d5494c3d1598R174-R184)

### Serialization and deserialization changes:

* Modified the `toItemStack` method in `Potion` to set the material to `Material.TIPPED_ARROW` for arrow potions. Adjusted how potion data is applied to the `PotionMeta`.
* Updated the `fromDamage` method in `Potion` to use the `switch` expression for cleaner code.

### Integration with other components:

* Updated `ZMenuItemStack` to read the `arrow` property from configuration and pass it to the `Potion` constructor.
* Updated `MenuItemStackLoader` and `ItemStackLoader` to handle the `arrow` property during potion loading from YAML configuration. [[1]](diffhunk://#diff-139f684eec1a8aeec98d09be9c98d07629006ae355fe7d52a03118eb1470ba3dR254-R256) [[2]](diffhunk://#diff-7c689199fa3b5cef653bc767c192be779d2aaa74b30b1382eb48f78c53849c38R68-R70)