### PR TITLE
Setup gradle plugin

### DIFF
--- a/API/build.gradle.kts
+++ b/API/build.gradle.kts
@@ -1,7 +1,5 @@
-import java.util.Locale
-
 plugins {
-    `maven-publish`
+    id("re.alwyn974.groupez.publish") version "1.0.0"
 }
 
 rootProject.extra.properties["sha"]?.let { sha ->
@@ -25,39 +23,6 @@ tasks {
     }
 }
 
-publishing {
-    var repository = System.getProperty("repository.name", "snapshots").replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }
-    repositories {
-        maven {
-            name = "groupez${repository}"
-            url = uri("https://repo.groupez.dev/${repository.lowercase()}")
-            credentials {
-                username = findProperty("${name}Username") as String? ?: System.getenv("MAVEN_USERNAME")
-                password = findProperty("${name}Password") as String? ?: System.getenv("MAVEN_PASSWORD")
-            }
-            authentication {
-                create<BasicAuthentication>("basic")
-            }
-        }
-    }
-
-    publications {
-        register<MavenPublication>("groupez${repository}") {
-            pom {
-                groupId = project.group as String?
-                name = "${rootProject.name}-${project.name}"
-                artifactId = name.get().lowercase()
-                version = project.version as String?
-
-                scm {
-                    connection = "scm:git:git://github.com/MaxLego08/${rootProject.name}.git"
-                    developerConnection = "scm:git:ssh://github.com/MaxLego08/${rootProject.name}.git"
-                    url = "https://github.com/MaxLego08/${rootProject.name}/"
-                }
-            }
-            artifact(tasks.shadowJar)
-            artifact(tasks.javadocJar)
-            artifact(tasks.sourcesJar)
-        }
-    }
+publishConfig {
+    githubOwner.set("MaxLego08")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,9 @@
-import org.gradle.internal.impldep.org.apache.commons.codec.digest.DigestUtils.sha
 import org.gradle.kotlin.dsl.invoke
 
 plugins {
     `java-library`
     id("com.gradleup.shadow") version "9.0.0-beta11"
+    id("re.alwyn974.groupez.repository") version "1.0.0-SNAPSHOT"
 }
 
 group = "fr.maxlego08.menu"
@@ -17,6 +17,7 @@ extra.set("sha", System.getProperty("github.sha"))
 allprojects {
     apply(plugin = "java-library")
     apply(plugin = "com.gradleup.shadow")
+    apply(plugin = "re.alwyn974.groupez.repository")
 
     group = "fr.maxlego08.menu"
     version = rootProject.version
@@ -25,14 +26,6 @@ allprojects {
         mavenLocal()
         mavenCentral()
 
-        maven {
-            name = "groupezReleases"
-            url = uri("https://repo.groupez.dev/releases")
-        }
-        maven {
-            name = "groupezSnapshots"
-            url = uri("https://repo.groupez.dev/snapshots")
-        }
         maven(url = "https://jitpack.io")
         maven(url = "https://hub.spigotmc.org/nexus/content/repositories/snapshots/")
         maven(url = "https://repo.extendedclip.com/content/repositories/placeholderapi/")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import org.gradle.kotlin.dsl.invoke
 plugins {
     `java-library`
     id("com.gradleup.shadow") version "9.0.0-beta11"
-    id("re.alwyn974.groupez.repository") version "1.0.0-SNAPSHOT"
+    id("re.alwyn974.groupez.repository") version "1.0.0"
 }
 
 group = "fr.maxlego08.menu"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,11 +5,10 @@ enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 pluginManagement {
     repositories {
         maven {
-            name = "groupez-releases"
+            name = "groupezReleases"
             url = uri("https://repo.groupez.dev/releases")
         }
         gradlePluginPortal()
-        mavenLocal()
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,18 @@ rootProject.name = "zMenu"
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
+pluginManagement {
+    repositories {
+        maven {
+            name = "groupez-releases"
+            url = uri("https://repo.groupez.dev/releases")
+        }
+        gradlePluginPortal()
+        mavenLocal()
+    }
+}
+
+
 include("API")
 
 file("Hooks").listFiles()?.forEach { file ->


### PR DESCRIPTION
This pull request refactors the build configuration for the project by replacing the custom Maven publishing setup with a standardized plugin and updating the plugin management repositories. The changes aim to simplify the configuration and improve maintainability.

### Build Configuration Refactor:

* [`API/build.gradle.kts`](diffhunk://#diff-341d3c67c4bd2f71ea1dfbde0586ee6a56c7c3bd87737c8519e176bff2469115L1-R2): Replaced the custom Maven publishing configuration with the `re.alwyn974.groupez.publish` plugin, removing manual repository and publication setup. [[1]](diffhunk://#diff-341d3c67c4bd2f71ea1dfbde0586ee6a56c7c3bd87737c8519e176bff2469115L1-R2) [[2]](diffhunk://#diff-341d3c67c4bd2f71ea1dfbde0586ee6a56c7c3bd87737c8519e176bff2469115L28-R27)

* [`settings.gradle.kts`](diffhunk://#diff-5625e3601fa0ad3a6a2824239e5a2fde71c149597d31394f9224a08c24be7b9dR5-R15): Added a `pluginManagement` block to configure repositories, including the `groupezReleases` repository and the Gradle Plugin Portal, for managing plugins more effectively.