### PR TITLE
Refactor PDCDupeManager persistant data type for dupe key

### DIFF
--- a/src/main/java/fr/maxlego08/menu/dupe/PDCDupeManager.java
+++ b/src/main/java/fr/maxlego08/menu/dupe/PDCDupeManager.java
@@ -34,7 +34,7 @@ public class PDCDupeManager implements DupeManager {
             ItemMeta itemMeta = itemStack.getItemMeta();
             if (itemMeta == null) return itemStack;
             PersistentDataContainer persistentDataContainer = itemMeta.getPersistentDataContainer();
-            persistentDataContainer.set(namespacedKey, PersistentDataType.INTEGER, 1);
+            persistentDataContainer.set(namespacedKey, PersistentDataType.BOOLEAN, true);
             itemStack.setItemMeta(itemMeta);
             return itemStack;
         } catch (Exception exception) {
@@ -57,6 +57,6 @@ public class PDCDupeManager implements DupeManager {
         if (itemMeta == null) return false;
 
         PersistentDataContainer persistentDataContainer = itemMeta.getPersistentDataContainer();
-        return persistentDataContainer.has(this.namespacedKey, PersistentDataType.INTEGER);
+        return persistentDataContainer.has(this.namespacedKey, PersistentDataType.BOOLEAN);
     }
 }


### PR DESCRIPTION
This pull request aims to use a boolean value for the dupe key in PDC, similar to what the NMSDupeManager already implements.