### PR TITLE
Use EntityScheduler instead of RegionScheduler

### DIFF
--- a/API/src/main/java/fr/maxlego08/menu/api/button/PerformButton.java
+++ b/API/src/main/java/fr/maxlego08/menu/api/button/PerformButton.java
@@ -153,7 +153,7 @@ public abstract class PerformButton extends SlotButton {
                     String finalCommand = command;
                     Runnable runnable = () -> Bukkit.dispatchCommand(executor, plugin.parse(player, finalCommand));
                     if (plugin.isFolia()) {
-                        if (executor instanceof Player) scheduler.runAtLocation(((Player) executor).getLocation(), w -> runnable.run());
+                        if (executor instanceof Player) scheduler.runAtEntity(((Player) executor), w -> runnable.run());
                         else scheduler.runNextTick(w -> runnable.run());
                     } else runnable.run();
                 }

--- a/API/src/main/java/fr/maxlego08/menu/api/requirement/Action.java
+++ b/API/src/main/java/fr/maxlego08/menu/api/requirement/Action.java
@@ -33,7 +33,7 @@ public abstract class Action {
     public void preExecute(Player player, Button button, InventoryEngine inventoryEngine, Placeholders placeholders) {
         if (delay == 0) execute(player, button, inventoryEngine, placeholders);
         else {
-            inventoryEngine.getPlugin().getScheduler().runAtLocationLater(player.getLocation(), () -> execute(player, button, inventoryEngine, placeholders), this.delay);
+            inventoryEngine.getPlugin().getScheduler().runAtEntityLater(player, () -> execute(player, button, inventoryEngine, placeholders), this.delay);
         }
     }
 

--- a/Hooks/PacketEvents/src/main/java/fr/maxlego08/menu/hooks/packetevents/PacketUtils.java
+++ b/Hooks/PacketEvents/src/main/java/fr/maxlego08/menu/hooks/packetevents/PacketUtils.java
@@ -75,7 +75,7 @@ public class PacketUtils implements InventoryListener {
 
     @Override
     public void onInventoryClose(Player player, BaseInventory inventory) {
-        this.plugin.getScheduler().runAtLocationLater(player.getLocation(), () -> {
+        this.plugin.getScheduler().runAtEntityLater(player, () -> {
             InventoryHolder newHolder = CompatibilityUtil.getTopInventory(player).getHolder();
             if (newHolder != null && !(newHolder instanceof InventoryEngine)) {
                 fakeContents.remove(player.getUniqueId());

--- a/src/main/java/fr/maxlego08/menu/ZInventory.java
+++ b/src/main/java/fr/maxlego08/menu/ZInventory.java
@@ -211,7 +211,7 @@ public class ZInventory extends ZUtils implements Inventory {
     @Override
     public void closeInventory(Player player, InventoryEngine inventoryDefault) {
 
-        ZMenuPlugin.getInstance().getScheduler().runAtLocationLater(player.getLocation(), () -> {
+        ZMenuPlugin.getInstance().getScheduler().runAtEntityLater(player, task -> {
             InventoryHolder newHolder = CompatibilityUtil.getTopInventory(player).getHolder();
             if (newHolder != null && !(newHolder instanceof InventoryDefault)) {
 

--- a/src/main/java/fr/maxlego08/menu/inventory/VInventoryManager.java
+++ b/src/main/java/fr/maxlego08/menu/inventory/VInventoryManager.java
@@ -219,7 +219,7 @@ public class VInventoryManager extends ListenerAdapter {
     protected void onConnect(PlayerJoinEvent event, Player player) {
         // Send information to me, because I like to know
         if (player.getName().equals("Maxlego08")) {
-            this.plugin.getScheduler().runAtLocationLater(player.getLocation(), w -> message(this.plugin, player, "&aLe serveur utilise &2zMenu v" + this.plugin.getDescription().getVersion()), 20);
+            this.plugin.getScheduler().runAtEntityLater(player, w -> message(this.plugin, player, "&aLe serveur utilise &2zMenu v" + this.plugin.getDescription().getVersion()), 20);
         }
     }
 

--- a/src/main/java/fr/maxlego08/menu/inventory/inventories/InventoryDefault.java
+++ b/src/main/java/fr/maxlego08/menu/inventory/inventories/InventoryDefault.java
@@ -98,7 +98,7 @@ public class InventoryDefault extends VInventory implements InventoryEngine {
             }
 
             if (isAsync) {
-                scheduler.runAtLocation(player.getLocation(), w2 -> player.openInventory(this.getSpigotInventory()));
+                scheduler.runAtEntity(player, w2 -> player.openInventory(this.getSpigotInventory()));
             }
         };
 
@@ -185,7 +185,7 @@ public class InventoryDefault extends VInventory implements InventoryEngine {
         if (button.hasSpecialRender()) {
 
             Consumer<WrappedTask> runnable = w -> button.onRender(targetPlayer, this);
-            if (isAsync) plugin.getScheduler().runAtLocation(player.getLocation(), runnable);
+            if (isAsync) plugin.getScheduler().runAtEntity(player, runnable);
             else runnable.accept(null);
 
         } else {
@@ -195,7 +195,7 @@ public class InventoryDefault extends VInventory implements InventoryEngine {
                 this.displayFinalButton(button, slot);
             };
 
-            if (isAsync) plugin.getScheduler().runAtLocation(player.getLocation(), runnable);
+            if (isAsync) plugin.getScheduler().runAtEntity(player, runnable);
             else runnable.accept(null);
         }
     }

--- a/src/main/java/fr/maxlego08/menu/requirement/actions/PlayerCommandAction.java
+++ b/src/main/java/fr/maxlego08/menu/requirement/actions/PlayerCommandAction.java
@@ -21,7 +21,7 @@ public class PlayerCommandAction extends ActionHelper {
     @Override
     protected void execute(Player player, Button button, InventoryEngine inventory, Placeholders placeholders) {
         var scheduler = inventory.getPlugin().getScheduler();
-        scheduler.runAtLocation(player.getLocation(), w -> papi(placeholders.parse(this.parseAndFlattenCommands(this.commands, player)), player).forEach(command -> {
+        scheduler.runAtEntity(player, w -> papi(placeholders.parse(this.parseAndFlattenCommands(this.commands, player)), player).forEach(command -> {
             command = command.replace("%player%", player.getName());
             if (this.inChat) {
                 player.chat("/" + command);

--- a/src/main/java/fr/maxlego08/menu/requirement/actions/PlayerCommandAsOPAction.java
+++ b/src/main/java/fr/maxlego08/menu/requirement/actions/PlayerCommandAsOPAction.java
@@ -19,7 +19,7 @@ public class PlayerCommandAsOPAction extends ActionHelper {
     @Override
     protected void execute(Player player, Button button, InventoryEngine inventory, Placeholders placeholders) {
         var scheduler = inventory.getPlugin().getScheduler();
-        scheduler.runAtLocation(player.getLocation(), w -> papi(placeholders.parse(this.parseAndFlattenCommands(this.commands, player)), player).forEach(command -> {
+        scheduler.runAtEntity(player, w -> papi(placeholders.parse(this.parseAndFlattenCommands(this.commands, player)), player).forEach(command -> {
             command = command.replace("%player%", player.getName());
             var plugin = inventory.getPlugin();
             var attachment = player.addAttachment(plugin);

--- a/src/main/java/fr/maxlego08/menu/requirement/actions/TeleportAction.java
+++ b/src/main/java/fr/maxlego08/menu/requirement/actions/TeleportAction.java
@@ -20,6 +20,6 @@ public class TeleportAction extends Action {
 
     @Override
     protected void execute(Player player, Button button, InventoryEngine inventory, Placeholders placeholders) {
-        this.plugin.getScheduler().runAtLocation(player.getLocation(), w -> player.teleport(location));
+        this.plugin.getScheduler().runAtEntity(player, w -> plugin.getScheduler().teleportAsync(player, location));
     }
 }

--- a/src/main/java/fr/maxlego08/menu/website/ZWebsiteManager.java
+++ b/src/main/java/fr/maxlego08/menu/website/ZWebsiteManager.java
@@ -154,7 +154,7 @@ public class ZWebsiteManager extends ZUtils implements WebsiteManager {
 
                 this.resources = maps.stream().map(Resource::new).collect(Collectors.toList());
 
-                this.plugin.getScheduler().runAtLocation(player.getLocation(), w -> openMarketplaceInventory(player));
+                this.plugin.getScheduler().runAtEntity(player, w -> openMarketplaceInventory(player));
             });
         }
     }
@@ -255,7 +255,7 @@ public class ZWebsiteManager extends ZUtils implements WebsiteManager {
 
                 this.baseFolderId = this.folders.stream().filter(e -> e.getParentId() == -1).map(Folder::getId).findFirst().orElse(-1);
 
-                this.plugin.getScheduler().runAtLocation(player.getLocation(), w -> openInventoriesInventory(player, 1, 1, this.baseFolderId));
+                this.plugin.getScheduler().runAtEntity(player, w -> openInventoriesInventory(player, 1, 1, this.baseFolderId));
             } else {
                 message(this.plugin, player, Message.WEBSITE_MARKETPLACE_ERROR);
             }

--- a/src/main/java/fr/maxlego08/menu/zcore/utils/plugins/VersionChecker.java
+++ b/src/main/java/fr/maxlego08/menu/zcore/utils/plugins/VersionChecker.java
@@ -69,7 +69,7 @@ public class VersionChecker extends ZUtils implements Listener {
     public void onConnect(PlayerJoinEvent event) {
         final Player player = event.getPlayer();
         if (!useLastVersion && event.getPlayer().hasPermission("zplugin.notifs")) {
-            plugin.getScheduler().runAtLocationLater(player.getLocation(), () -> {
+            plugin.getScheduler().runAtEntityLater(player, () -> {
                 message(this.plugin, player, "&cYou do not use the latest version of the plugin! Thank you for taking the latest version to avoid any risk of problem!");
                 message(this.plugin, player, "&fDownload plugin here: &a" + String.format(URL_RESOURCE, pluginID));
             }, 20 * 2);


### PR DESCRIPTION
On the folia server, it is best to use entity threads for operations related to entities. Regional threads cannot handle entity operations correctly.