### PR TITLE
Fixed inventory reloading and compatibility issues

### DIFF
--- a/src/main/java/fr/maxlego08/menu/ZMenuPlugin.java
+++ b/src/main/java/fr/maxlego08/menu/ZMenuPlugin.java
@@ -163,6 +163,7 @@ public class ZMenuPlugin extends ZPlugin implements MenuPlugin {
         this.registerCommand("zmenu", this.commandMenu = new CommandMenu(this), "zm");
 
         /* Add Listener */
+        this.addListener(new SwapKeyListener());
         this.addListener(new AdapterListener(this));
         this.addListener(this.vinventoryManager);
         this.addListener(this.inventoriesPlayer);
@@ -194,11 +195,6 @@ public class ZMenuPlugin extends ZPlugin implements MenuPlugin {
         File tokenFile = new File(this.getDataFolder(), "token.json");
         if (tokenFile.exists()) {
             Token.getInstance().load(this.getPersist());
-        }
-
-        // Must register after config loads
-        if (!Bukkit.getVersion().contains("*")) {
-            this.addListener(new SwapKeyListener());
         }
 
         new VersionChecker(this, 253).useLastVersion();

--- a/src/main/java/fr/maxlego08/menu/ZMenuPlugin.java
+++ b/src/main/java/fr/maxlego08/menu/ZMenuPlugin.java
@@ -197,7 +197,7 @@ public class ZMenuPlugin extends ZPlugin implements MenuPlugin {
         }
 
         // Must register after config loads
-        if (!Bukkit.getVersion().contains("1.8")) {
+        if (!Bukkit.getVersion().contains("*")) {
             this.addListener(new SwapKeyListener());
         }
 

--- a/src/main/java/fr/maxlego08/menu/command/commands/reload/CommandMenuReloadCommand.java
+++ b/src/main/java/fr/maxlego08/menu/command/commands/reload/CommandMenuReloadCommand.java
@@ -38,7 +38,7 @@ public class CommandMenuReloadCommand extends VCommand {
             Command command = optional.get();
             plugin.getVInventoryManager().close(v -> {
                 InventoryDefault inventoryDefault = (InventoryDefault) v;
-                return !inventoryDefault.isClose() && inventoryDefault.getMenuInventory().getFileName().equals(command.getInventory());
+                return !inventoryDefault.isClose() && inventoryDefault.getMenuInventory().getFileName().equals(command.inventory());
             });
 
             Message message = commandManager.reload(command) ? Message.RELOAD_COMMAND_FILE

--- a/src/main/java/fr/maxlego08/menu/command/commands/reload/CommandMenuReloadCommand.java
+++ b/src/main/java/fr/maxlego08/menu/command/commands/reload/CommandMenuReloadCommand.java
@@ -39,7 +39,7 @@ public class CommandMenuReloadCommand extends VCommand {
             Command command = optional.get();
             plugin.getVInventoryManager().close(v -> {
                 InventoryDefault inventoryDefault = (InventoryDefault) v;
-                return !inventoryDefault.isClose() && inventoryDefault.getInventory().equals(command.getInventory());
+                return !inventoryDefault.isClose() && inventoryDefault.getMenuInventory().getFileName().equals(command.getInventory());
             });
 
             Message message = commandManager.reload(command) ? Message.RELOAD_COMMAND_FILE

--- a/src/main/java/fr/maxlego08/menu/command/commands/reload/CommandMenuReloadInventory.java
+++ b/src/main/java/fr/maxlego08/menu/command/commands/reload/CommandMenuReloadInventory.java
@@ -49,7 +49,7 @@ public class CommandMenuReloadInventory extends VCommand {
             Inventory inventory = optional.get();
             plugin.getVInventoryManager().close(v -> {
                 InventoryDefault inventoryDefault = (InventoryDefault) v;
-                return !inventoryDefault.isClose() && inventoryDefault.getInventory().equals(inventory);
+                return !inventoryDefault.isClose() && inventoryDefault.getMenuInventory().equals(inventory);
             });
             inventoryManager.reloadInventory(inventory);
             message(plugin, this.sender, Message.RELOAD_INVENTORY_FILE, "%name%", inventoryName);

--- a/src/main/java/fr/maxlego08/menu/dupe/PDCDupeManager.java
+++ b/src/main/java/fr/maxlego08/menu/dupe/PDCDupeManager.java
@@ -27,12 +27,6 @@ public class PDCDupeManager implements DupeManager {
                 return null;
             }
 
-            /*
-            if (!itemStack.hasItemMeta()) {
-                return itemStack;
-            }
-            */
-
             ItemMeta itemMeta = itemStack.getItemMeta();
             if (itemMeta == null) return itemStack;
             PersistentDataContainer persistentDataContainer = itemMeta.getPersistentDataContainer();

--- a/src/main/java/fr/maxlego08/menu/dupe/PDCDupeManager.java
+++ b/src/main/java/fr/maxlego08/menu/dupe/PDCDupeManager.java
@@ -27,9 +27,11 @@ public class PDCDupeManager implements DupeManager {
                 return null;
             }
 
+            /*
             if (!itemStack.hasItemMeta()) {
                 return itemStack;
             }
+            */
 
             ItemMeta itemMeta = itemStack.getItemMeta();
             if (itemMeta == null) return itemStack;

--- a/src/main/java/fr/maxlego08/menu/inventory/VInventoryManager.java
+++ b/src/main/java/fr/maxlego08/menu/inventory/VInventoryManager.java
@@ -205,14 +205,12 @@ public class VInventoryManager extends ListenerAdapter {
 
     public void close(Predicate<VInventory> predicate) {
         Bukkit.getOnlinePlayers().stream().filter(player -> {
-            InventoryHolder holder = CompatibilityUtil.getTopInventory(player).getHolder();
-            return holder instanceof VInventory;
-        }).map(player -> (VInventory) CompatibilityUtil.getTopInventory(player).getHolder()).filter(predicate).filter(Objects::nonNull).forEach(vInventory -> {
-            Player player = vInventory.getPlayer();
-            if (player.isOnline()) {
-                player.closeInventory();
+            if (player.getOpenInventory().getType() != InventoryType.CHEST) {
+                return false;
             }
-        });
+            InventoryHolder holder = CompatibilityUtil.getTopInventory(player).getHolder();
+            return holder instanceof VInventory vInventory && predicate.test(vInventory);
+        }).forEach(Player::closeInventory);
     }
 
     @Override


### PR DESCRIPTION
Fixed inventory reloading and compatibility issues

- Removed unnecessary item metadata check in PDCDupeManager to fix /zmenu testdupe command
- Fixed inventory reloading issues by correctly comparing filenames instead of inventory instances
- Improved VInventoryManager shutdown logic to only handle CHEST inventories to fix compatibility issues on folia servers
- Removed useless version check condition to fix the problem of not registering SwapKeyListener in version 1.21.8
- Fixed incorrect judgment condition in CommandMenuReloadInventory.java