### PR TITLE
Cache configuration file lines to reduce IO

### DIFF
--- a/src/main/java/fr/maxlego08/menu/command/commands/reload/CommandMenuReload.java
+++ b/src/main/java/fr/maxlego08/menu/command/commands/reload/CommandMenuReload.java
@@ -7,6 +7,7 @@ import fr.maxlego08.menu.api.configuration.Config;
 import fr.maxlego08.menu.api.utils.Message;
 import fr.maxlego08.menu.command.VCommand;
 import fr.maxlego08.menu.zcore.enums.Permission;
+import fr.maxlego08.menu.zcore.utils.ZUtils;
 import fr.maxlego08.menu.zcore.utils.commands.CommandType;
 
 public class CommandMenuReload extends VCommand {
@@ -25,6 +26,8 @@ public class CommandMenuReload extends VCommand {
     protected CommandType perform(ZMenuPlugin plugin) {
 
         InventoryManager inventoryManager = plugin.getInventoryManager();
+
+        ZUtils.clearConfigurationCache();
 
         plugin.loadGlobalPlaceholders();
         plugin.getMessageLoader().load();


### PR DESCRIPTION
## Summary
- introduce a concurrent cache of configuration file lines in `ZUtils` that stores the last modification timestamp
- update `loadAndReplaceConfiguration` to reuse cached content while performing placeholder substitution on local copies and expose a cache clearing hook
- clear the configuration cache during the full `/zmenu reload` command to honor manual file changes without redundant disk reads

## Testing
- ./gradlew compileJava

------
https://chatgpt.com/codex/tasks/task_e_68d022740a708321848af6c9d2790928