### PR TITLE
Developement

### DIFF
--- a/API/src/main/java/fr/maxlego08/menu/api/MenuItemStack.java
+++ b/API/src/main/java/fr/maxlego08/menu/api/MenuItemStack.java
@@ -8,6 +8,7 @@ import fr.maxlego08.menu.api.enums.MenuItemRarity;
 import fr.maxlego08.menu.api.itemstack.*;
 import fr.maxlego08.menu.api.utils.LoreType;
 import fr.maxlego08.menu.api.utils.Placeholders;
+import org.bukkit.NamespacedKey;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
@@ -380,7 +381,7 @@ public interface MenuItemStack extends MenuItemStackContext {
      *
      * @param itemModel the item model identifier to set.
      */
-    void setItemModel(String itemModel);
+    void setItemModel(NamespacedKey itemModel);
 
     /**
      * Sets the equipped model identifier used for wearable items.

--- a/API/src/main/java/fr/maxlego08/menu/api/context/MenuItemStackContext.java
+++ b/API/src/main/java/fr/maxlego08/menu/api/context/MenuItemStackContext.java
@@ -6,6 +6,7 @@ import fr.maxlego08.menu.api.attribute.AttributeWrapper;
 import fr.maxlego08.menu.api.enums.MenuItemRarity;
 import fr.maxlego08.menu.api.itemstack.*;
 import fr.maxlego08.menu.api.utils.LoreType;
+import org.bukkit.NamespacedKey;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
@@ -326,7 +327,7 @@ public interface MenuItemStackContext {
      *
      * @return the item model identifier.
      */
-    String getItemModel();
+    NamespacedKey getItemModel();
 
     /**
      * Retrieves the equipped model identifier used for wearable items.

--- a/API/src/main/java/fr/maxlego08/menu/api/engine/BaseInventory.java
+++ b/API/src/main/java/fr/maxlego08/menu/api/engine/BaseInventory.java
@@ -27,19 +27,19 @@ public interface BaseInventory extends InventoryHolder {
     @Contract(pure = true)
     boolean isClose();
 
-    @Contract("_, null -> null")
+    @Contract("_, null -> null; _, !null -> !null")
     @Nullable
     ItemButton addItem(int slot, @Nullable ItemStack itemStack);
 
-    @Contract("_, null,_ -> null")
+    @Contract("_, null, _ -> null; _, !null, _ -> !null")
     @Nullable
     ItemButton addItem(int slot, @Nullable ItemStack itemStack, boolean enableAntiDupe);
 
-    @Contract("_, _, null -> null")
+    @Contract("_, _, null -> null; _, _, !null -> !null")
     @Nullable
     ItemButton addItem(boolean inPlayerInventory, int slot, @Nullable ItemStack itemStack);
 
-    @Contract("_, _, null, _ -> null")
+    @Contract("_, _, null, _ -> null; _, _, !null, _ -> !null")
     @Nullable
     ItemButton addItem(boolean inPlayerInventory, int slot, @Nullable ItemStack itemStack, boolean enableAntiDupe);
 

--- a/API/src/main/java/fr/maxlego08/menu/api/utils/Message.java
+++ b/API/src/main/java/fr/maxlego08/menu/api/utils/Message.java
@@ -108,9 +108,9 @@ public enum Message implements IMessage {
     RELOAD("&aYou have just reloaded the configuration files. &8(&7%inventories% inventories&8)"),
     RELOAD_INVENTORY("&aYou have just reloaded the inventories files. &8(&7%inventories% inventories&8)"),
     RELOAD_DIALOGS("&aYou have just reloaded the dialogs files. &8(&7%dialogs% dialogs&8)"),
-    RELOAD_INVENTORY_FILE("&aVous have just reloaded the inventory &f%name%&a."),
+    RELOAD_INVENTORY_FILE("&aYou have just reloaded the inventory &f%name%&a."),
     RELOAD_COMMAND("&aYou have just reloaded the commands files."),
-    RELOAD_COMMAND_FILE("&aVous have just reloaded the command &f%name%&a."),
+    RELOAD_COMMAND_FILE("&aYou have just reloaded the command &f%name%&a."),
     RELOAD_COMMAND_ERROR("&cIt is not possible to reload the command &f%name%&c."),
     RELOAD_FILES("&aYou have just reloaded config.json and messages.yml files."),
 

--- a/Common/src/main/java/fr/maxlego08/menu/ZMenuItemStack.java
+++ b/Common/src/main/java/fr/maxlego08/menu/ZMenuItemStack.java
@@ -61,7 +61,7 @@ public class ZMenuItemStack extends ZUtils implements MenuItemStack {
     private Map<String, List<String>> translatedLore = new HashMap<>();
     private boolean isGlowing;
     private String modelID;
-    private String itemModel;
+    private NamespacedKey itemModel;
     private String equippedModel;
     private Map<Enchantment, Integer> enchantments = new HashMap<>();
     private boolean clearDefaultAttributes = false;
@@ -474,10 +474,7 @@ public class ZMenuItemStack extends ZUtils implements MenuItemStack {
             }
         }
         if (this.itemModel != null) {
-            String[] itemModelSplit = this.itemModel.split(":", 2);
-            if (itemModelSplit.length == 2) {
-                itemMeta.setItemModel(new NamespacedKey(itemModelSplit[0], itemModelSplit[1]));
-            }
+            itemMeta.setItemModel(this.itemModel);
         }
 
         if (this.equippedModel != null) {
@@ -768,12 +765,12 @@ public class ZMenuItemStack extends ZUtils implements MenuItemStack {
     }
 
     @Override
-    public String getItemModel() {
+    public NamespacedKey getItemModel() {
         return itemModel;
     }
 
     @Override
-    public void setItemModel(String itemModel) {
+    public void setItemModel(NamespacedKey itemModel) {
         this.itemModel = itemModel;
     }
 

--- a/Common/src/main/java/fr/maxlego08/menu/common/utils/yaml/YamlParser.java
+++ b/Common/src/main/java/fr/maxlego08/menu/common/utils/yaml/YamlParser.java
@@ -148,13 +148,18 @@ public class YamlParser {
     }
 
 
-    @NotNull
-    private static String parseStringValue(@NotNull String value, @NotNull Map<String, Object> placeholders) {
+    @Nullable
+    private static Object parseStringValue(@NotNull String value, @NotNull Map<String, Object> placeholders) {
         String result = value;
 
         for (Map.Entry<String, Object> entry : placeholders.entrySet()) {
             String key = entry.getKey();
             Object placeholderValue = entry.getValue();
+
+            if (placeholderValue instanceof List<?> list && list.isEmpty() && result.equalsIgnoreCase("%" + key + "%")) {
+                return null;
+            }
+
             String replacementValue = placeholderValue != null ? placeholderValue.toString() : "";
             
             result = PLACEHOLDER_PARSER.parse(result, key, replacementValue);
@@ -194,7 +199,10 @@ public class YamlParser {
         for (Object listElement : listValue) {
             Map<String, Object> tempPlaceholders = new HashMap<>(placeholders);
             tempPlaceholders.put(listPlaceholderKey, listElement);
-            expandedStrings.add(parseStringValue(string, tempPlaceholders));
+            Object parsedValue = parseStringValue(string, tempPlaceholders);
+            if (parsedValue instanceof String parsedString) {
+                expandedStrings.add(parsedString);
+            }
         }
         return expandedStrings;
     }

--- a/Hooks/PacketEvents/src/main/java/fr/maxlego08/menu/hooks/packetevents/listener/PacketAnimationListener.java
+++ b/Hooks/PacketEvents/src/main/java/fr/maxlego08/menu/hooks/packetevents/listener/PacketAnimationListener.java
@@ -62,6 +62,7 @@ public class PacketAnimationListener implements PacketListener {
             WrapperPlayServerOpenWindow wrapper = new WrapperPlayServerOpenWindow(event);
             int containerId = wrapper.getContainerId();
             Player player = event.getPlayer();
+            if (player == null) return;
             UUID playerUniqueId = player.getUniqueId();
 
             PlayerAnimationData data = this.playerAnimationData.get(playerUniqueId);
@@ -97,6 +98,7 @@ public class PacketAnimationListener implements PacketListener {
             }
         } else if (packetType == PacketType.Play.Server.CLOSE_WINDOW){
             Player player = event.getPlayer();
+            if (player == null) return;
             Inventory topInventory = CompatibilityUtil.getTopInventory(player);
             if (topInventory == null) {
                 return;
@@ -118,6 +120,7 @@ public class PacketAnimationListener implements PacketListener {
         } else if (packetType == PacketType.Play.Server.WINDOW_ITEMS){
             WrapperPlayServerWindowItems wrapper = new WrapperPlayServerWindowItems(event);
             Player player = event.getPlayer();
+            if (player == null) return;
             UUID playerUniqueId = player.getUniqueId();
 
             int windowId = wrapper.getWindowId();

--- a/Hooks/PacketEvents/src/main/java/fr/maxlego08/menu/hooks/packetevents/listener/PacketEventClickLimiterListener.java
+++ b/Hooks/PacketEvents/src/main/java/fr/maxlego08/menu/hooks/packetevents/listener/PacketEventClickLimiterListener.java
@@ -23,6 +23,7 @@ public class PacketEventClickLimiterListener implements PacketListener {
         PacketTypeCommon packetType = event.getPacketType();
         if (packetType == PacketType.Play.Client.CLICK_WINDOW) {
             Player player = event.getPlayer();
+            if (player == null) return;
             Inventory topInventory = CompatibilityUtil.getTopInventory(player);
             try {
                 if (topInventory != null && topInventory.getHolder() instanceof BaseInventory baseInventory && baseInventory.isClickLimiterEnabled()) {

--- a/Hooks/PacketEvents/src/main/java/fr/maxlego08/menu/hooks/packetevents/listener/PacketTitleListener.java
+++ b/Hooks/PacketEvents/src/main/java/fr/maxlego08/menu/hooks/packetevents/listener/PacketTitleListener.java
@@ -43,16 +43,19 @@ public class PacketTitleListener implements PacketListener {
         if (packetType == PacketType.Play.Server.OPEN_WINDOW){
             WrapperPlayServerOpenWindow wrapper = new WrapperPlayServerOpenWindow(event);
             Player player = event.getPlayer();
+            if (player == null) return;
             UUID playerUniqueId = player.getUniqueId();
             this.playerPacketInformation.computeIfAbsent(playerUniqueId, k -> new PlayerPacketInformation())
                     .setWrapperPlayServerOpenWindow(wrapper);
         } else if (packetType == PacketType.Play.Server.CLOSE_WINDOW){
             Player player = event.getPlayer();
+            if (player == null) return;
             UUID playerUniqueId = player.getUniqueId();
             this.playerPacketInformation.remove(playerUniqueId);
         } else if (packetType == PacketType.Play.Server.WINDOW_ITEMS){
             WrapperPlayServerWindowItems wrapper = new WrapperPlayServerWindowItems(event);
             Player player = event.getPlayer();
+            if (player == null) return;
             UUID playerUniqueId = player.getUniqueId();
             this.playerPacketInformation.computeIfAbsent(playerUniqueId, k -> new PlayerPacketInformation())
                     .setWrapperPlayServerWindowItems(wrapper);

--- a/Hooks/Paper/src/main/java/fr/maxlego08/menu/hooks/ComponentMeta.java
+++ b/Hooks/Paper/src/main/java/fr/maxlego08/menu/hooks/ComponentMeta.java
@@ -207,6 +207,6 @@ public class ComponentMeta extends MiniMessageColorUtils implements PaperMetaUpd
 
     @Override
     public String getLegacyMessage(String message) {
-        return LegacyComponentSerializer.legacySection().serialize(this.getComponent(message));
+        return message == null ? null : LegacyComponentSerializer.legacySection().serialize(this.getComponent(message));
     }
 }

--- a/Hooks/Paper/src/main/java/fr/maxlego08/menu/hooks/ComponentMeta.java
+++ b/Hooks/Paper/src/main/java/fr/maxlego08/menu/hooks/ComponentMeta.java
@@ -166,9 +166,6 @@ public class ComponentMeta extends MiniMessageColorUtils implements PaperMetaUpd
         return createInventoryInternal(inventoryName, inventoryHolder, inventoryType);
     }
 
-
-
-
     @Override
     public void sendMessage(@NonNull CommandSender sender, @NonNull String message) {
         Component component = this.cache.get(message, () -> this.MINI_MESSAGE.deserialize(colorMiniMessage(message)));

--- a/src/main/java/fr/maxlego08/menu/ZComponentsManager.java
+++ b/src/main/java/fr/maxlego08/menu/ZComponentsManager.java
@@ -51,7 +51,7 @@ public class ZComponentsManager implements ComponentsManager {
             this.registerComponent(new SpigotCustomModelDataItemComponentLoader());
             this.registerComponent(new SpigotDamageItemComponentLoader());
             this.registerComponent(new SpigotDamageResistantItemComponentLoader());
-            this.registerComponent(new SpigotDyeColorItemComponentLoader());
+            this.registerComponent(new SpigotDyedColorItemComponentLoader());
             this.registerComponent(new SpigotEnchantmentGlintOverrideItemComponentLoader());
             this.registerComponent(new SpigotFireworkExplosionItemComponentLoader());
             this.registerComponent(new SpigotFireworksItemComponentLoader());

--- a/src/main/java/fr/maxlego08/menu/ZInventory.java
+++ b/src/main/java/fr/maxlego08/menu/ZInventory.java
@@ -18,7 +18,6 @@ import fr.maxlego08.menu.api.utils.OpenWithItem;
 import fr.maxlego08.menu.api.utils.Placeholders;
 import fr.maxlego08.menu.common.utils.ZUtils;
 import fr.maxlego08.menu.inventory.inventories.InventoryDefault;
-import fr.maxlego08.menu.zcore.logger.Logger;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.InventoryHolder;
@@ -257,7 +256,6 @@ public class ZInventory extends ZUtils implements Inventory {
             if (button.isPlayerInventory()) {
                 for (int slot : button.getSlots()) {
                     if (slot >= 0 && slot <= 36) {
-                        Logger.info("Clearing player inventory slot " + slot + " for player " + player.getName());
                         this.clearInvType.getOnButtonClear().accept(player, slot);
                     }
                 }

--- a/src/main/java/fr/maxlego08/menu/inventory/VInventoryManager.java
+++ b/src/main/java/fr/maxlego08/menu/inventory/VInventoryManager.java
@@ -180,8 +180,8 @@ public class VInventoryManager extends ListenerAdapter implements VInvManager {
     @Override
     protected void onInventoryDrag(InventoryDragEvent event, Player player) {
         InventoryHolder holder = CompatibilityUtil.getTopInventory(event).getHolder();
-        if (holder instanceof VInventory) {
-            ((VInventory) holder).onDrag(event, this.plugin, player);
+        if (holder instanceof VInventory vInventory) {
+            vInventory.onDrag(event, this.plugin, player);
         }
     }
 

--- a/src/main/java/fr/maxlego08/menu/loader/MenuItemStackLoader.java
+++ b/src/main/java/fr/maxlego08/menu/loader/MenuItemStackLoader.java
@@ -97,9 +97,7 @@ public class MenuItemStackLoader extends ZUtils implements Loader<MenuItemStack>
         if (NmsVersion.getCurrentVersion().isNewHeadApi()) {
             loadTrims(menuItemStack, configuration, path, file);
         }
-        if (NmsVersion.getCurrentVersion().isNewItemModelAPI()) {
-            menuItemStack.setItemModel(configuration.getString(path + "item-model"));
-        }
+        this.loadItemModel(configuration, menuItemStack, path, file);
 
         if (NmsVersion.getCurrentVersion().isAttributItemStack()) { // 1.20.5+
             ConfigurationSection componentsSection = configuration.getConfigurationSection(path + "components.");
@@ -149,6 +147,25 @@ public class MenuItemStackLoader extends ZUtils implements Loader<MenuItemStack>
             }
         }
         menuItemStack.setLore(lore);
+    }
+
+    private void loadItemModel(@NonNull YamlConfiguration configuration, ZMenuItemStack menuItemStack, @NonNull String path, File file) {
+        if (NmsVersion.getCurrentVersion().isNewItemModelAPI()) {
+            String itemModel = configuration.getString(path + "item-model");
+            if (itemModel != null) {
+                try {
+                    NamespacedKey namespacedKey = NamespacedKey.fromString(itemModel.toLowerCase());
+                    if (namespacedKey != null) {
+                        menuItemStack.setItemModel(namespacedKey);
+                    }
+                } catch (Exception e) {
+                    if (Configuration.enableDebug) {
+                        Logger.info("An error occurred while loading the item model " + itemModel + " for file " + file.getAbsolutePath() + " with path " + path, Logger.LogType.WARNING);
+                        e.printStackTrace();
+                    }
+                }
+            }
+        }
     }
 
     /**
@@ -472,10 +489,7 @@ public class MenuItemStackLoader extends ZUtils implements Loader<MenuItemStack>
         if (tooltypestyleString != null) {
             menuItemStack.setToolTipStyle(tooltypestyleString);
         }
-        String itemModelString = configuration.getString(path + "item-model", null);
-        if (itemModelString != null) {
-            menuItemStack.setItemModel(itemModelString);
-        }
+        this.loadItemModel(configuration, menuItemStack, path, file);
         String equippedModel = configuration.getString(path + "equipped-model", null);
         if (equippedModel != null) {
             menuItemStack.setEquippedModel(equippedModel);

--- a/src/main/java/fr/maxlego08/menu/loader/components/spigot/SpigotDamageTypeItemComponentLoader.java
+++ b/src/main/java/fr/maxlego08/menu/loader/components/spigot/SpigotDamageTypeItemComponentLoader.java
@@ -21,8 +21,8 @@ public class SpigotDamageTypeItemComponentLoader extends ItemComponentLoader {
 
     @Override
     public @Nullable ItemComponent load(@NotNull MenuItemStackContext context, @NotNull File file, @NotNull YamlConfiguration configuration, @NotNull String path, @Nullable ConfigurationSection componentSection) {
-        path = normalizePath(path);
-        String damageType = configuration.getString(path);
+        if (componentSection == null) return null;
+        String damageType = componentSection.getString("types");
         if (damageType != null) {
             NamespacedKey key = NamespacedKey.fromString(damageType);
             if (key != null) {

--- a/src/main/java/fr/maxlego08/menu/loader/components/spigot/SpigotDyedColorItemComponentLoader.java
+++ b/src/main/java/fr/maxlego08/menu/loader/components/spigot/SpigotDyedColorItemComponentLoader.java
@@ -12,9 +12,9 @@ import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 
-public class SpigotDyeColorItemComponentLoader extends AbstractColorItemComponentLoader {
+public class SpigotDyedColorItemComponentLoader extends AbstractColorItemComponentLoader {
 
-    public SpigotDyeColorItemComponentLoader(){
+    public SpigotDyedColorItemComponentLoader(){
         super("dyed-color");
     }
 


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes across the codebase, with a focus on stronger type safety for item model identifiers, improved null handling and validation, and some minor code cleanups. The most significant change is the migration of item model fields and methods from using `String` to `NamespacedKey`, ensuring better validation and consistency for item models. Additional improvements include enhanced null checks in event listeners, improved YAML parsing logic, and minor bug fixes and code cleanups.

**Type safety and API improvements:**
- Changed the type of the `itemModel` field and related getter/setter methods in `MenuItemStack`, `MenuItemStackContext`, and `ZMenuItemStack` from `String` to `NamespacedKey` to enforce proper namespacing and validation. Corresponding loader logic was updated to parse and validate the namespaced key from configuration files. [[1]](diffhunk://#diff-b38284c0ff63ceb184858ecc788746921202ac0187409aab4da38e35f119d5cdR11) [[2]](diffhunk://#diff-b38284c0ff63ceb184858ecc788746921202ac0187409aab4da38e35f119d5cdL383-R384) [[3]](diffhunk://#diff-edb08374fb7372bd4b6f76882dc051c37fe675319483e0e989719e1cabaf0d89R9) [[4]](diffhunk://#diff-edb08374fb7372bd4b6f76882dc051c37fe675319483e0e989719e1cabaf0d89L329-R330) [[5]](diffhunk://#diff-8ee6101b08df5d1ab53ebac20fb2dc86d74972948816c2a824ed09ffedcb5319L64-R64) [[6]](diffhunk://#diff-8ee6101b08df5d1ab53ebac20fb2dc86d74972948816c2a824ed09ffedcb5319L477-R477) [[7]](diffhunk://#diff-8ee6101b08df5d1ab53ebac20fb2dc86d74972948816c2a824ed09ffedcb5319L771-R773) [[8]](diffhunk://#diff-139f684eec1a8aeec98d09be9c98d07629006ae355fe7d52a03118eb1470ba3dL100-R100) [[9]](diffhunk://#diff-139f684eec1a8aeec98d09be9c98d07629006ae355fe7d52a03118eb1470ba3dR152-R170) [[10]](diffhunk://#diff-139f684eec1a8aeec98d09be9c98d07629006ae355fe7d52a03118eb1470ba3dL475-R492)

**Null and error handling improvements:**
- Added null checks for `Player` objects in various packet event listeners to prevent potential `NullPointerException`s. [[1]](diffhunk://#diff-21a3b1ec81c2c3c060971ce3937144941aa470e5c208043b91599a8394f509d1R65) [[2]](diffhunk://#diff-21a3b1ec81c2c3c060971ce3937144941aa470e5c208043b91599a8394f509d1R101) [[3]](diffhunk://#diff-21a3b1ec81c2c3c060971ce3937144941aa470e5c208043b91599a8394f509d1R123) [[4]](diffhunk://#diff-acf80f386056bfceda93fc9afbb503903eac78e8ce6484935ebdf78791507747R26) [[5]](diffhunk://#diff-955602ec02e2bb0b50858dd235f7eebc61a9ce5fd0302b70586fbb0f0d3e8bf7R46-R58)

**YAML parsing and placeholder logic:**
- Improved YAML placeholder parsing to return `null` when a placeholder references an empty list, and updated expansion logic to handle this scenario gracefully. [[1]](diffhunk://#diff-f93a147728b76b0c84208f7af5d6770559a02508feda85c680a1058b8ea29d0fL151-R162) [[2]](diffhunk://#diff-f93a147728b76b0c84208f7af5d6770559a02508feda85c680a1058b8ea29d0fL197-R205)

**Minor bug fixes and cleanups:**
- Fixed typos in user-facing reload messages in the `Message` enum.
- Fixed a bug in the `SpigotDamageTypeItemComponentLoader` to correctly read the damage type from the component section.
- Updated component registration to use the correct class name for dyed color item components.
- Improved null handling in legacy message serialization, and removed unused logger import and debug log line. [[1]](diffhunk://#diff-9d064f747a247a423e93bdb0c35d262c91736318c6abbeaf4718e4e9c439faccL210-R207) [[2]](diffhunk://#diff-baccf42ad17d47a6de4817f93e1e6c7b381ce82ed055523d64b5db49197ce930L21) [[3]](diffhunk://#diff-baccf42ad17d47a6de4817f93e1e6c7b381ce82ed055523d64b5db49197ce930L260)
- Minor refactor to use pattern matching when handling inventory drag events.