### PR TITLE
Fix caching logic

### DIFF
--- a/Common/src/main/java/fr/maxlego08/menu/ZMenuItemStack.java
+++ b/Common/src/main/java/fr/maxlego08/menu/ZMenuItemStack.java
@@ -1200,4 +1200,16 @@ public class ZMenuItemStack extends ZUtils implements MenuItemStack {
     public void addItemComponent(@NotNull ItemComponent itemMetadata) {
         this.itemComponents.add(itemMetadata);
     }
+
+    public boolean isDynamicMaterial() {
+        if (this.material == null) return false;
+        if (this.material.contains("%")) return true;
+        if (this.material.contains(":")) {
+            String[] values = this.material.split(":", 2);
+            if (values.length == 2) {
+                return this.inventoryManager.getMaterialLoader(values[0]).isPresent();
+            }
+        }
+        return false;
+    }
 }

--- a/src/main/java/fr/maxlego08/menu/loader/MenuItemStackLoader.java
+++ b/src/main/java/fr/maxlego08/menu/loader/MenuItemStackLoader.java
@@ -126,7 +126,7 @@ public class MenuItemStackLoader extends ZUtils implements Loader<MenuItemStack>
             }
         }
 
-        if (!menuItemStack.isNeedPlaceholderAPI() && Configuration.enableCacheItemStack) {
+        if (!menuItemStack.isNeedPlaceholderAPI() && Configuration.enableCacheItemStack && !menuItemStack.isDynamicMaterial()) {
             try {
                 menuItemStack.build(new ZBuildContext.Builder().build());
             } catch (Exception ignored) { // Fail when a item requires a player to be built.


### PR DESCRIPTION
This pull request introduces a refinement to how item stacks are cached by adding a check for dynamic materials, ensuring that items with dynamic or placeholder-based materials are not cached prematurely. The main changes are:

Caching logic improvements:

* Added a new method `isDynamicMaterial()` to `ZMenuItemStack` to determine if an item's material is dynamic by checking for placeholders (`%`) or special material syntax (`:`), and verifying if the material loader is present.
* Updated the caching condition in `MenuItemStackLoader` to prevent caching of item stacks with dynamic materials, avoiding potential issues with items that require runtime evaluation.