### PR TITLE
add MMOItems support

### DIFF
--- a/Hooks/MMOItems/build.gradle.kts
+++ b/Hooks/MMOItems/build.gradle.kts
@@ -1,0 +1,12 @@
+group = "Hooks:MythicMobs"
+
+repositories {
+    mavenCentral()
+    maven(url = "https://nexus.phoenixdevt.fr/repository/maven-public/")
+}
+
+
+dependencies {
+    compileOnly(projects.common)
+    compileOnly("net.Indyuce:MMOItems-API:6.9.5-SNAPSHOT")
+}

--- a/Hooks/MMOItems/src/main/java/fr/maxlego08/menu/hooks/mmoitems/MMOItemsLoader.java
+++ b/Hooks/MMOItems/src/main/java/fr/maxlego08/menu/hooks/mmoitems/MMOItemsLoader.java
@@ -1,0 +1,30 @@
+package fr.maxlego08.menu.hooks.mmoitems;
+
+import fr.maxlego08.menu.api.loader.MaterialLoader;
+import net.Indyuce.mmoitems.MMOItems;
+import net.Indyuce.mmoitems.api.Type;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class MMOItemsLoader extends MaterialLoader {
+
+    public MMOItemsLoader() {
+        super("mmoitems");
+    }
+
+    @Override
+    public @Nullable ItemStack load(@NotNull Player player, @Nullable YamlConfiguration configuration, @NotNull String path, @NotNull String materialString) {
+        String[] split = materialString.split(":",2);
+        if (split.length != 2) return null;
+        try {
+            final Type type = MMOItems.plugin.getTypes().get(split[0]);
+            if (type == null) return null;
+            return MMOItems.plugin.getItem(type, split[1]);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,3 +22,5 @@ file("Hooks").listFiles()?.forEach { file ->
         include(":Hooks:${file.name}")
     }
 }
+
+include("Hooks:MMOItems")

--- a/src/main/java/fr/maxlego08/menu/ZMenuPlugin.java
+++ b/src/main/java/fr/maxlego08/menu/ZMenuPlugin.java
@@ -38,6 +38,7 @@ import fr.maxlego08.menu.hooks.executableitems.ExecutableItemsLoader;
 import fr.maxlego08.menu.hooks.headdatabase.HeadDatabaseLoader;
 import fr.maxlego08.menu.hooks.itemsadder.ItemsAdderFont;
 import fr.maxlego08.menu.hooks.itemsadder.ItemsAdderLoader;
+import fr.maxlego08.menu.hooks.mmoitems.MMOItemsLoader;
 import fr.maxlego08.menu.hooks.mythicmobs.MythicManager;
 import fr.maxlego08.menu.hooks.mythicmobs.MythicMobsItemsLoader;
 import fr.maxlego08.menu.hooks.packetevents.PacketEventPlayerInventoryManager;
@@ -360,6 +361,10 @@ public class ZMenuPlugin extends ZPlugin implements MenuPlugin {
         if (this.isActive(Plugins.BREWERYX)) {
             this.inventoryManager.registerMaterialLoader(new BreweryXLoader());
             this.getLogger().info("Registered BreweryX material loader");
+        }
+        if (this.isActive(Plugins.MMOITEMS)) {
+            this.inventoryManager.registerMaterialLoader(new MMOItemsLoader());
+            this.getLogger().info("Registered MMOItems material loader");
         }
         if (this.isActive(Plugins.PACKETEVENTS)){
             this.titleAnimationManager.registerLoader("packet-events", new PacketEventTitleAnimationLoader());

--- a/src/main/java/fr/maxlego08/menu/zcore/utils/plugins/Plugins.java
+++ b/src/main/java/fr/maxlego08/menu/zcore/utils/plugins/Plugins.java
@@ -28,8 +28,8 @@ public enum Plugins {
     MYTHICMOBS("MythicMobs"),
 	ZMENUPLUS("zMenuPlus"),
     BREWERYX("BreweryX"),
-    PACKETEVENTS("packetevents")
-    ;
+    PACKETEVENTS("packetevents"),
+    MMOITEMS("MMOItems");
 	private final String name;
 
 	Plugins(String name) {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -22,6 +22,7 @@ softdepend:
   - ExecutableBlocks
   - MythicMobs
   - BreweryX
+  - MMOItems
 folia-supported: true
 loadbefore:
   - SuperiorSkyblock2


### PR DESCRIPTION
This pull request adds support for the MMOItems plugin integration. The main changes include introducing a new `MMOItemsLoader` class for loading MMOItems materials, updating dependency management, and ensuring the plugin recognizes MMOItems as an optional dependency.

**MMOItems integration:**

* Added new class `MMOItemsLoader` in `Hooks/MMOItems/src/main/java/fr/maxlego08/menu/hooks/mmoitems/MMOItemsLoader.java` to handle loading MMOItems items via the API.
* Registered `MMOItemsLoader` in the main plugin initialization (`ZMenuPlugin.java`) so it is used when MMOItems is active.

**Dependency and build configuration:**

* Created a new Gradle build configuration for the MMOItems hook in `Hooks/MMOItems/build.gradle.kts`, including the MMOItems API as a compile-only dependency.
* Included `Hooks:MMOItems` in the Gradle settings to ensure the module is built.

**Plugin system updates:**

* Added `MMOITEMS` to the `Plugins` enum so it can be recognized and activated.
* Declared `MMOItems` as a `softdepend` in `plugin.yml` to indicate optional support.