### PR TITLE
fix: remove unnecessary toLowerCase conversion in dialog name and cle…

### DIFF
--- a/Common/src/main/java/fr/maxlego08/menu/ZMenuItemStack.java
+++ b/Common/src/main/java/fr/maxlego08/menu/ZMenuItemStack.java
@@ -38,8 +38,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jspecify.annotations.NonNull;
 
-import javax.annotation.Nullable;
-import java.io.File;
 import java.util.*;
 
 public class ZMenuItemStack extends ZUtils implements MenuItemStack {

--- a/src/main/java/fr/maxlego08/menu/command/commands/dialogs/CommandDialogOpen.java
+++ b/src/main/java/fr/maxlego08/menu/command/commands/dialogs/CommandDialogOpen.java
@@ -23,7 +23,7 @@ public class CommandDialogOpen extends VCommand {
         this.addRequireArg("dialog name", (a, b) -> {
             List<String> dialogs = new ArrayList<>();
             for (DialogInventory dialog : dialogManager.getDialogs()) {
-                dialogs.add((dialog.getPlugin().getName() + ":" + dialog.getFileName()).toLowerCase());
+                dialogs.add((dialog.getPlugin().getName() + ":" + dialog.getFileName()));
             }
             return dialogs;
         });


### PR DESCRIPTION

This pull request includes minor cleanup and consistency improvements in the codebase. The changes remove an unused import and ensure dialog names are not forcibly lowercased when generating argument suggestions.

- Code cleanup:
  * Removed an unused import of `javax.annotation.Nullable` and `java.io.File` from `ZMenuItemStack.java`.

- Consistency in dialog name handling:
  * Updated the dialog name suggestion logic in `CommandDialogOpen.java` to stop converting dialog names to lowercase, preserving their original case.