### PR TITLE
Enchant open-with-item action

### DIFF
--- a/API/src/main/java/fr/maxlego08/menu/api/utils/ClickAction.java
+++ b/API/src/main/java/fr/maxlego08/menu/api/utils/ClickAction.java
@@ -1,0 +1,27 @@
+package fr.maxlego08.menu.api.utils;
+
+import org.bukkit.event.block.Action;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public enum ClickAction {
+    LEFT_CLICK(Action.LEFT_CLICK_BLOCK, Action.LEFT_CLICK_AIR),
+    RIGHT_CLICK(Action.RIGHT_CLICK_BLOCK, Action.RIGHT_CLICK_AIR),
+    LEFT_CLICK_BLOCK(Action.LEFT_CLICK_BLOCK),
+    RIGHT_CLICK_BLOCK(Action.RIGHT_CLICK_BLOCK),
+    LEFT_CLICK_AIR(Action.LEFT_CLICK_AIR),
+    RIGHT_CLICK_AIR(Action.RIGHT_CLICK_AIR),
+    PHYSICAL(Action.PHYSICAL)
+    ;
+    private final List<Action> actions;
+
+    ClickAction(Action ... actions) {
+        this.actions = List.of(actions);
+    }
+
+    @NotNull
+    public List<Action> asActions() {
+        return this.actions;
+    }
+}

--- a/src/main/java/fr/maxlego08/menu/loader/InventoryLoader.java
+++ b/src/main/java/fr/maxlego08/menu/loader/InventoryLoader.java
@@ -19,6 +19,7 @@ import fr.maxlego08.menu.api.pattern.Pattern;
 import fr.maxlego08.menu.api.pattern.PatternManager;
 import fr.maxlego08.menu.api.requirement.Requirement;
 import fr.maxlego08.menu.api.utils.ClearInvType;
+import fr.maxlego08.menu.api.utils.ClickAction;
 import fr.maxlego08.menu.api.utils.Loader;
 import fr.maxlego08.menu.api.utils.OpenWithItem;
 import fr.maxlego08.menu.common.utils.ZUtils;
@@ -33,10 +34,7 @@ import org.jspecify.annotations.NonNull;
 
 import java.io.File;
 import java.lang.reflect.Constructor;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 public class InventoryLoader extends ZUtils implements Loader<Inventory> {
 
@@ -248,18 +246,20 @@ public class InventoryLoader extends ZUtils implements Loader<Inventory> {
                 MenuItemStack loadedItem = menuItemStackLoader.load(configuration, loadString + ".item.", file);
 
                 List<String> actionStrings = configuration.getStringList(loadString + ".actions");
-                List<Action> actions = new ArrayList<>(actionStrings.size());
+                Set<Action> actions = new HashSet<>();
                 for (String string : actionStrings) {
                     try {
-                        actions.add(Action.valueOf(string.toUpperCase()));
+                        actions.addAll(ClickAction.valueOf(string.toUpperCase()).asActions());
                     } catch (Exception ignored) {
+                        if (Configuration.enableDebug)
+                            Logger.info("Invalid click action " + string + " in " + file.getAbsolutePath() + " for openWithItem, skipping it.", Logger.LogType.WARNING);
                     }
                 }
 
                 String type = configuration.getString(loadString + ".type", "full");
                 ItemStackSimilar itemStackSimilar = this.plugin.getInventoryManager().getItemStackVerification(type).orElseGet(FullSimilar::new);
 
-                inventory.setOpenWithItem(new OpenWithItem(loadedItem, actions, itemStackSimilar));
+                inventory.setOpenWithItem(new OpenWithItem(loadedItem, new ArrayList<>(actions), itemStackSimilar));
             }
         } catch (Exception ignored) {
         }


### PR DESCRIPTION
This pull request introduces a new `ClickAction` enum to centralize and simplify the handling of click actions, and refactors the logic for loading click actions from configuration files in the `InventoryLoader` class. The changes improve code maintainability, make action mapping more flexible, and add better error handling and debugging information.

**Refactoring and code improvements:**

* Added a new `ClickAction` enum in `fr.maxlego08.menu.api.utils` to group related Bukkit `Action` values and provide a convenient method for retrieving associated actions.
* Refactored `InventoryLoader` to use the new `ClickAction` enum when parsing click actions from configuration, replacing direct use of `Action.valueOf` with `ClickAction.valueOf(...).asActions()`. This allows for more flexible and robust mapping of configuration strings to actions.

**Error handling and debugging:**

* Enhanced error handling in `InventoryLoader` by logging a warning message when an invalid click action is encountered in the configuration, including the file path for easier debugging.

**Code cleanup:**

* Cleaned up imports in `InventoryLoader` by consolidating multiple import statements into a single wildcard import for utility classes.
* Added the import for the new `ClickAction` enum in `InventoryLoader`.…entoryLoader