### PR TITLE
Fix: block item pickup when clear-inventory is enabled

### DIFF
--- a/src/main/java/fr/maxlego08/menu/inventory/VInventoryManager.java
+++ b/src/main/java/fr/maxlego08/menu/inventory/VInventoryManager.java
@@ -191,7 +191,7 @@ public class VInventoryManager extends ListenerAdapter implements VInvManager {
         if (holder instanceof VInventory vInventory) {
             if (vInventory instanceof InventoryDefault inventoryDefault) {
                 fr.maxlego08.menu.api.Inventory menu = inventoryDefault.getMenuInventory();
-                if (menu != null && menu.shouldCancelItemPickup()) {
+                if (menu != null && (menu.shouldCancelItemPickup() || menu.cleanInventory())) {
                     event.setCancelled(true);
                 }
             }


### PR DESCRIPTION
Prevents players from picking up items while in a menu with clear-inventory enabled, as those items would be lost when the inventory is restored on close.