### PR TITLE
optimize inventory lookup with map cache

### DIFF
--- a/src/main/java/fr/maxlego08/menu/ZInventoryManager.java
+++ b/src/main/java/fr/maxlego08/menu/ZInventoryManager.java
@@ -91,6 +91,7 @@ public class ZInventoryManager extends ZUtils implements InventoryManager {
 
     private final Map<UUID, Integer> playerPages = new HashMap<>();
     private final Map<UUID, Integer> playerMaxPages = new HashMap<>();
+    private final Map<String, Inventory> inventoryByName = new HashMap<>();
 
     private final List<InventoryLoadRequirement> inventoryLoadRequirements = new ArrayList<>();
 
@@ -210,6 +211,7 @@ public class ZInventoryManager extends ZUtils implements InventoryManager {
         List<Inventory> inventories = this.inventories.getOrDefault(plugin.getName(), new ArrayList<>());
         inventories.add(inventory);
         this.inventories.put(plugin.getName(), inventories);
+        this.inventoryByName.put(inventory.getFileName().toLowerCase(), inventory);
 
         if (Configuration.enableInformationMessage) {
             Logger.info(file.getPath() + " loaded successfully !", LogType.INFO);
@@ -240,12 +242,7 @@ public class ZInventoryManager extends ZUtils implements InventoryManager {
         if (name == null) {
             return Optional.empty();
         }
-        for (Inventory inventory : this.getInventories()) {
-            if (inventory.getFileName().equalsIgnoreCase(name)) {
-                return Optional.of(inventory);
-            }
-        }
-        return Optional.empty();
+        return Optional.ofNullable(this.inventoryByName.get(name.toLowerCase()));
     }
 
     @Override
@@ -287,6 +284,7 @@ public class ZInventoryManager extends ZUtils implements InventoryManager {
         List<Inventory> inventories = this.inventories.getOrDefault(pluginName, new ArrayList<>());
         inventories.remove(inventory);
         this.inventories.put(pluginName, inventories);
+        this.inventoryByName.remove(inventory.getFileName().toLowerCase());
     }
 
     @Override
@@ -301,7 +299,10 @@ public class ZInventoryManager extends ZUtils implements InventoryManager {
 
     @Override
     public void deleteInventories(Plugin plugin) {
-        this.inventories.remove(plugin.getName());
+        List<Inventory> removed = this.inventories.remove(plugin.getName());
+        if (removed != null) {
+            removed.forEach(inv -> this.inventoryByName.remove(inv.getFileName().toLowerCase()));
+        }
     }
 
     @Override
@@ -474,6 +475,7 @@ public class ZInventoryManager extends ZUtils implements InventoryManager {
 
         this.playerMaxPages.clear();
         this.playerPages.clear();
+        this.inventoryByName.clear();
 
         File folder = new File(this.plugin.getDataFolder(), "inventories");
         if (!folder.exists()) {


### PR DESCRIPTION
Replaced O(n) linear scan in getInventory(name) with O(1) HashMap lookup. Cache is populated on inventory load and synced on delete/reload operations.