### PR TITLE
Add debug logging for item loading and fix economy plugin

### DIFF
--- a/Hooks/Eco/src/main/java/fr/maxlego08/menu/hooks/EcoLoader.java
+++ b/Hooks/Eco/src/main/java/fr/maxlego08/menu/hooks/EcoLoader.java
@@ -3,7 +3,9 @@ package fr.maxlego08.menu.hooks;
 import com.willfp.eco.core.items.Items;
 import fr.maxlego08.menu.api.annotations.AutoMaterialLoader;
 import fr.maxlego08.menu.api.annotations.RequiresPlugin;
+import fr.maxlego08.menu.api.configuration.Configuration;
 import fr.maxlego08.menu.api.loader.MaterialLoader;
+import fr.maxlego08.menu.zcore.logger.Logger;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -23,7 +25,10 @@ public class EcoLoader extends MaterialLoader {
             //eco item lookup system:
             // https://plugins.auxilor.io/all-plugins/the-item-lookup-system
             return Items.lookup(materialString).getItem();
-        } catch (Exception ignored) {
+        } catch (Exception exception) {
+            if (Configuration.enableDebug) {
+                Logger.info("Failed to load eco item: " + materialString + " for player: " + player.getName() + ", reason: " + exception.getMessage()+".");
+            }
             return null;
         }
     }

--- a/src/main/java/fr/maxlego08/menu/ZItemManager.java
+++ b/src/main/java/fr/maxlego08/menu/ZItemManager.java
@@ -102,7 +102,7 @@ public class ZItemManager implements ItemManager {
                             factory.parse(this.menuPlugin, itemId, mechanicSection.getConfigurationSection(mechanicId), config, file, path + mechanicId + ".");
                             mechanicIds.add(mechanicId);
                         } else {
-                            Logger.info("No MechanicFactory found for mechanicId " + mechanicId + " in item " + itemId, Logger.LogType.WARNING);
+                            Logger.info("No MechanicFactory found for mechanicId " + mechanicId + " in item " + itemId + " from file " + file.getName() + "(available factories: " + this.mechanicFactories.keySet() + ")", Logger.LogType.WARNING);
                         }
                     }
                 }

--- a/src/main/java/fr/maxlego08/menu/ZItemManager.java
+++ b/src/main/java/fr/maxlego08/menu/ZItemManager.java
@@ -9,6 +9,7 @@ import fr.maxlego08.menu.api.mechanic.MechanicFactory;
 import fr.maxlego08.menu.api.mechanic.MechanicListener;
 import fr.maxlego08.menu.item.CustomItemData;
 import fr.maxlego08.menu.mechanics.itemjoin.ItemJoinMechanicFactory;
+import fr.maxlego08.menu.mechanics.onclick.OnClickMechanicFactory;
 import fr.maxlego08.menu.zcore.logger.Logger;
 import org.bukkit.NamespacedKey;
 import org.bukkit.configuration.ConfigurationSection;
@@ -50,6 +51,7 @@ public class ZItemManager implements ItemManager {
 
     private void loadMechanics(){
         this.registerMechanicFactory(new ItemJoinMechanicFactory(this.menuPlugin));
+        this.registerMechanicFactory(new OnClickMechanicFactory(this.menuPlugin));
     }
 
     @Override

--- a/src/main/resources/paper-plugin.yml
+++ b/src/main/resources/paper-plugin.yml
@@ -145,3 +145,40 @@ dependencies:
       load: BEFORE
       required: false
       join-classpath: true
+
+    # -- Economy plugins
+    Vault:
+      join-classpath: true
+
+    BeastTokens:
+      join-classpath: true
+
+    PlayerPoints:
+      join-classpath: true
+
+    ElementalTokens:
+      join-classpath: true
+
+    ElementalGems:
+      join-classpath: true
+
+    zEssentials:
+      join-classpath: true
+
+    EcoBits:
+      join-classpath: true
+
+    CoinsEngine:
+      join-classpath: true
+
+    ExcellentEconomy:
+      join-classpath: true
+
+    VotingPlugin:
+      join-classpath: true
+
+    RedisEconomy:
+      join-classpath: true
+
+    RoyaleEconomy:
+      join-classpath: true

--- a/src/main/resources/paper-plugin.yml
+++ b/src/main/resources/paper-plugin.yml
@@ -148,37 +148,49 @@ dependencies:
 
     # -- Economy plugins
     Vault:
+      required: false
       join-classpath: true
 
     BeastTokens:
+      required: false
       join-classpath: true
 
     PlayerPoints:
+      required: false
       join-classpath: true
 
     ElementalTokens:
+      required: false
       join-classpath: true
 
     ElementalGems:
+      required: false
       join-classpath: true
 
     zEssentials:
+      required: false
       join-classpath: true
 
     EcoBits:
+      required: false
       join-classpath: true
 
     CoinsEngine:
+      required: false
       join-classpath: true
 
     ExcellentEconomy:
+      required: false
       join-classpath: true
 
     VotingPlugin:
+      required: false
       join-classpath: true
 
     RedisEconomy:
+      required: false
       join-classpath: true
 
     RoyaleEconomy:
+      required: false
       join-classpath: true


### PR DESCRIPTION
This pull request introduces improved error logging for eco item loading, adds support for a new mechanic, and expands the list of supported economy plugins. The most important changes are summarized below.

### Improved error handling and logging

* Enhanced error logging in `EcoLoader`: When an eco item fails to load, a detailed message is now logged if debug mode is enabled, including the item name, player, and exception reason.

### Mechanics support

* Registered `OnClickMechanicFactory`: The `ZItemManager` now registers the `OnClickMechanicFactory`, enabling support for "on click" mechanics in the plugin.

### Economy plugin integration

* Added economy plugins to `paper-plugin.yml`: Multiple economy plugins (such as Vault, BeastTokens, PlayerPoints, and others) are now listed as optional dependencies, allowing for broader compatibility with different server economies.

### Codebase improvements

* Imported necessary classes: Added imports for `Configuration` and `Logger` to `EcoLoader`, ensuring proper access to configuration and logging utilities.
* Imported `OnClickMechanicFactory` in `ZItemManager` to support the new mechanic registration.